### PR TITLE
Contribute pretext language as xml language

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
         "onCommand:pretext-tools.refresh"
     ],
     "main": "./out/extension.js",
+    "extensionDependencies": [
+      "redhat.vscode-xml"
+    ],
     "contributes": {
         "languages": [
             {
@@ -147,6 +150,11 @@
                 "title": "Update installed PreTeXt version",
                 "category": "PreTeXt Tools",
                 "description": "Checks for and installs the newest version of PreTeXt"
+            }
+        ],
+        "xmlLanguageParticipants": [
+            {
+                "languageId": "pretext"
             }
         ]
     },


### PR DESCRIPTION
This PR provides the capability to associate the pretext language with the XML Language Server of vscode-xml.

To test this PR, you need to wait a release of vscode-xml (planed for tomorrow). You will benefit with all features of vscode-xml.

If you wish to benefit with XML completion / validation from pretext.rng, pretext.rnc, pretext.dtd or pretext.xsd, without adding an xml-model processing instruction, you will need to add in the settings project:

```json
"xml.fileAssociations": [
      {
         "pattern": "**/*.ptx",
         "systemId": "path/to/pretext.rng"
      }
   ]
```

Here a demo:

![PretextDemo](https://user-images.githubusercontent.com/1932211/207650837-9c574e12-b29d-4c07-a3fd-eabb8cb41fce.gif)
