### PR TITLE
Add 'prefigure' to verbatimTags for formatter

### DIFF
--- a/packages/vscode-extension/src/formatter.ts
+++ b/packages/vscode-extension/src/formatter.ts
@@ -193,6 +193,7 @@ const verbatimTags = [
   "output",
   "prompt",
   "pre",
+  "prefigure",
   "pg-code",
   "tikzpicture",
   "tikz",

--- a/packages/vscode-extension/src/lsp-server/formatter-classic.ts
+++ b/packages/vscode-extension/src/lsp-server/formatter-classic.ts
@@ -196,6 +196,7 @@ const verbatimTags = [
   "sageplot",
   "asymptote",
   "macros",
+  "prefigure",
   "program",
   "input",
   "output",


### PR DESCRIPTION
While it would be nice to have the extension understand and format PreFigure code, this is a temporary stop-gap to make the formatter leave PreFigure code blocks alone.