### PR TITLE
add formatter cli

### DIFF
--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -1,24 +1,26 @@
 # PreTeXt Formatter
 
-A utility to format PreTeXt source. To use,
+A utility to format PreTeXt source.
 
-```
+## Install
+
+```sh
 npm install @pretextbook/format
 ```
 
-and then import the formatter in your code:
+## Library usage
 
-```javascript
-import { formatPreTeXt } from "@pretextbook/format";
+```js
+import { formatPretext } from "@pretextbook/format";
 
 const formatted = formatPretext(sourceCode);
 ```
 
-You can pass options as an object to customize the formatting. For example:
+You can pass options to customize formatting:
 
-```javascript
+```js
 const options = {
-  blankLines: "many",
+  breakLines: "many",
   breakSentences: true,
   insertSpaces: true,
   tabSize: 2,
@@ -27,7 +29,41 @@ const options = {
 const formatted = formatPretext(sourceCode, options);
 ```
 
-This allows you to specify the maximum line length and indentation level for the formatted output.
+## CLI usage
+
+The package also exposes a CLI:
+
+```sh
+pretext-format [options] [files...]
+```
+
+Examples:
+
+```sh
+# Print a formatted file to stdout
+pretext-format chapter.ptx
+
+# Write formatting changes in-place
+pretext-format --write chapter.ptx section.ptx
+
+# Check whether files are already formatted (exit 1 if not)
+pretext-format --check chapter.ptx
+
+# Format stdin and print to stdout
+cat chapter.ptx | pretext-format --stdin
+```
+
+Options:
+
+- `-w, --write` write formatted output back to files
+- `--check` check formatting only (no writes)
+- `--stdin` read input from stdin
+- `--break-lines <few|some|many>` choose line break density
+- `--break-sentences` break plain-text sentences onto new lines
+- `--tab-size <n>` set spaces per indent level
+- `--use-tabs` indent with tabs instead of spaces
+- `-h, --help` show help
+- `-v, --version` show version
 
 ## Building
 

--- a/packages/format/README.md
+++ b/packages/format/README.md
@@ -37,20 +37,38 @@ The package also exposes a CLI:
 pretext-format [options] [files...]
 ```
 
-Examples:
+Recommended workflow (inside a project):
+
+```sh
+# Install in your project (usually as a dev dependency)
+npm install -D @pretextbook/format
+
+# Run the project-local CLI
+npx pretext-format --write chapter.ptx
+# or
+npm exec -- pretext-format --write chapter.ptx
+```
+
+One-off run without adding a dependency:
+
+```sh
+npm exec --package @pretextbook/format -- pretext-format --check chapter.ptx
+```
+
+More examples:
 
 ```sh
 # Print a formatted file to stdout
-pretext-format chapter.ptx
+npx pretext-format chapter.ptx
 
 # Write formatting changes in-place
-pretext-format --write chapter.ptx section.ptx
+npx pretext-format --write chapter.ptx section.ptx
 
 # Check whether files are already formatted (exit 1 if not)
-pretext-format --check chapter.ptx
+npx pretext-format --check chapter.ptx
 
 # Format stdin and print to stdout
-cat chapter.ptx | pretext-format --stdin
+cat chapter.ptx | npx pretext-format --stdin
 ```
 
 Options:

--- a/packages/format/cli.cjs
+++ b/packages/format/cli.cjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const { parseArgs } = require("node:util");
+const { formatPretext } = require("./index.cjs");
+
+function printHelp() {
+  process.stdout.write(`Usage: pretext-format [options] [files...]
+
+Format PreTeXt files or stdin.
+
+Options:
+  -w, --write                Write formatted output back to files
+      --check                Check formatting without writing changes
+      --stdin                Read input from stdin
+      --break-lines <mode>   Line break mode: few | some | many
+      --break-sentences      Break plain-text sentences onto new lines
+      --tab-size <n>         Number of spaces per indent level
+      --use-tabs             Indent with tabs instead of spaces
+  -h, --help                 Show this help
+  -v, --version              Show package version
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(2);
+}
+
+function parseCli() {
+  try {
+    return parseArgs({
+      options: {
+        write: { type: "boolean", short: "w", default: false },
+        check: { type: "boolean", default: false },
+        stdin: { type: "boolean", default: false },
+        "break-lines": { type: "string" },
+        "break-sentences": { type: "boolean", default: false },
+        "tab-size": { type: "string" },
+        "use-tabs": { type: "boolean", default: false },
+        help: { type: "boolean", short: "h", default: false },
+        version: { type: "boolean", short: "v", default: false },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+  } catch (error) {
+    fail(error.message);
+  }
+}
+
+function parseOptions(values) {
+  /** @type {{breakLines?: "few" | "some" | "many"; breakSentences?: boolean; insertSpaces?: boolean; tabSize?: number}} */
+  const formatOptions = {};
+  if (values["break-lines"] !== undefined) {
+    if (!["few", "some", "many"].includes(values["break-lines"])) {
+      fail(`--break-lines must be one of: few, some, many`);
+    }
+    formatOptions.breakLines = values["break-lines"];
+  }
+  if (values["break-sentences"]) {
+    formatOptions.breakSentences = true;
+  }
+  if (values["use-tabs"]) {
+    formatOptions.insertSpaces = false;
+  }
+  if (values["tab-size"] !== undefined) {
+    const tabSize = Number.parseInt(values["tab-size"], 10);
+    if (!Number.isInteger(tabSize) || tabSize <= 0) {
+      fail(`--tab-size must be a positive integer`);
+    }
+    formatOptions.tabSize = tabSize;
+  }
+  return formatOptions;
+}
+
+function readFile(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    fail(`Could not read ${filePath}: ${error.message}`);
+  }
+}
+
+function writeFile(filePath, text) {
+  try {
+    fs.writeFileSync(filePath, text, "utf8");
+  } catch (error) {
+    fail(`Could not write ${filePath}: ${error.message}`);
+  }
+}
+
+function main() {
+  const { values, positionals } = parseCli();
+
+  if (values.help) {
+    printHelp();
+    return;
+  }
+  if (values.version) {
+    process.stdout.write(`${require("./package.json").version}\n`);
+    return;
+  }
+
+  if (values.stdin && positionals.length > 0) {
+    fail(`--stdin cannot be combined with file arguments`);
+  }
+  if (values.stdin && values.write) {
+    fail(`--write cannot be used with --stdin`);
+  }
+  if (values.stdin === false && positionals.length === 0) {
+    fail(`Provide files or use --stdin`);
+  }
+  if (positionals.length > 1 && !values.write && !values.check) {
+    fail(`Multiple files require --write or --check`);
+  }
+
+  const formatOptions = parseOptions(values);
+
+  if (values.stdin) {
+    const input = fs.readFileSync(0, "utf8");
+    const formatted = formatPretext(input, formatOptions);
+    if (values.check) {
+      if (formatted !== input) {
+        process.stderr.write("stdin is not formatted\n");
+        process.exit(1);
+      }
+      return;
+    }
+    process.stdout.write(formatted);
+    return;
+  }
+
+  let hasUnformatted = false;
+  for (const filePath of positionals) {
+    const input = readFile(filePath);
+    const formatted = formatPretext(input, formatOptions);
+    if (values.check) {
+      if (formatted !== input) {
+        hasUnformatted = true;
+        process.stderr.write(`${filePath}\n`);
+      }
+      continue;
+    }
+    if (values.write) {
+      if (formatted !== input) {
+        writeFile(filePath, formatted);
+      }
+      continue;
+    }
+    process.stdout.write(formatted);
+  }
+
+  if (values.check && hasUnformatted) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -17,6 +17,9 @@
   "main": "./index.cjs",
   "module": "./index.js",
   "types": "./index.d.ts",
+  "bin": {
+    "pretext-format": "./cli.cjs"
+  },
   "exports": {
     ".": {
       "types": "./index.d.ts",
@@ -31,6 +34,7 @@
     "*.cjs",
     "*.d.ts",
     "*.d.cts",
+    "cli.cjs",
     "dist"
   ],
   "scripts": {

--- a/packages/format/src/lib/cli.spec.ts
+++ b/packages/format/src/lib/cli.spec.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { formatPretext } from "./format";
+
+const cliPath = fileURLToPath(new URL("../../cli.cjs", import.meta.url));
+
+function runCli(args: string[], input?: string) {
+  return spawnSync("node", [cliPath, ...args], {
+    encoding: "utf8",
+    input,
+  });
+}
+
+describe("pretext-format CLI", () => {
+  it("formats stdin to stdout", () => {
+    const input = "<pretext><section><title>t</title></section></pretext>";
+    const result = runCli(["--stdin"], input);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("\n  <section>");
+    expect(result.stdout).not.toBe(input);
+  });
+
+  it("returns exit code 1 for --check when a file needs formatting", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pretext-format-"));
+    const filePath = join(tempDir, "sample.ptx");
+    try {
+      writeFileSync(
+        filePath,
+        "<pretext><section><title>t</title></section></pretext>",
+        "utf8",
+      );
+      const result = runCli(["--check", filePath]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(filePath);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns exit code 0 for --check when a file is already formatted", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pretext-format-"));
+    const filePath = join(tempDir, "sample.ptx");
+    try {
+      const formatted = formatPretext(
+        "<pretext><section><title>t</title></section></pretext>",
+      );
+      writeFileSync(
+        filePath,
+        formatted,
+        "utf8",
+      );
+      const result = runCli(["--check", filePath]);
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes formatted output in-place with --write", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pretext-format-"));
+    const filePath = join(tempDir, "sample.ptx");
+    try {
+      writeFileSync(
+        filePath,
+        "<pretext><section><title>t</title></section></pretext>",
+        "utf8",
+      );
+      const result = runCli(["--write", filePath]);
+      expect(result.status).toBe(0);
+      const updated = readFileSync(filePath, "utf8");
+      expect(updated).toContain("\n  <section>");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
The goal of this PR is to include a CLI for the format package that can be called on the command line or by python/bash as part of a build or CI workflow to format a set of pretext documents.