### PR TITLE
improve handling of unrecognized markdown

### DIFF
--- a/.changeset/lovely-taxes-design.md
+++ b/.changeset/lovely-taxes-design.md
@@ -1,0 +1,5 @@
+---
+"@pretextbook/remark-pretext": patch
+---
+
+Syntax highlighting for markdown-style pretext

--- a/packages/remark-pretext/src/lib/mdast-to-ptxast.ts
+++ b/packages/remark-pretext/src/lib/mdast-to-ptxast.ts
@@ -35,24 +35,25 @@ import type {
   ListItem,
   Blockquote as MdastBlockquote,
   Code,
-} from 'mdast';
-import type { ContainerDirective } from 'mdast-util-directive';
-import type { Math as CustomMath } from './math-parser.js';
-import type { Root } from 'xast';
-import type { Element } from 'xast';
-import { getDirectiveSpec, DIRECTIVE_MAP } from './directive-map.js';
-import { buildDirectiveWithSpec } from './directive-factory.js';
-import type { VisitContext, ConversionMessage } from './context.js';
+} from "mdast";
+import type { ContainerDirective } from "mdast-util-directive";
+import type { Math as CustomMath } from "./math-parser.js";
+import type { Root } from "xast";
+import type { Element } from "xast";
+import { getDirectiveSpec, DIRECTIVE_MAP } from "./directive-map.js";
+import { buildDirectiveWithSpec } from "./directive-factory.js";
+import type { VisitContext, ConversionMessage } from "./context.js";
 
 // ---------------------------------------------------------------------------
 // Xast node builders (local helpers for this module)
 // ---------------------------------------------------------------------------
 
-type XastText = { type: 'text'; value: string };
-type XastChild = Element | XastText;
+type XastText = { type: "text"; value: string };
+type XastComment = { type: "comment"; value: string };
+type XastChild = Element | XastText | XastComment;
 
 function text(value: string): XastText {
-  return { type: 'text', value };
+  return { type: "text", value };
 }
 
 function el(
@@ -61,16 +62,56 @@ function el(
   attributes?: Record<string, string>,
 ): Element {
   return {
-    type: 'element',
+    type: "element",
     name,
     attributes: attributes ?? {},
-    children: children as Element['children'],
+    children: children as Element["children"],
   };
 }
 
 /** Create a value element: single text child holds the raw string content. */
-function valueEl(name: string, value: string, attributes?: Record<string, string>): Element {
+function valueEl(
+  name: string,
+  value: string,
+  attributes?: Record<string, string>,
+): Element {
   return el(name, [text(value)], attributes);
+}
+
+function comment(value: string): XastComment {
+  // XML comments cannot contain '--'; replace to keep output well-formed
+  return { type: "comment", value: value.replace(/--/g, "- -") };
+}
+
+/** Extract the original source text for a node using its position offsets. */
+function nodeSource(node: unknown, ctx: VisitContext): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pos = (node as any)?.position;
+  const start: number | undefined = pos?.start?.offset;
+  const end: number | undefined = pos?.end?.offset;
+  if (ctx.source && start != null && end != null) {
+    return ctx.source.slice(start, end);
+  }
+  return "";
+}
+
+/**
+ * Build a <TODO> placeholder for unrecognized block content.
+ * Structure: <TODO type="..."><!-- todo: ... --><pre>raw source</pre></TODO>
+ * The XML comment is compatible with PreTeXt's author.tools="yes" mechanism.
+ * The schema-invalid <TODO> element surfaces as a validation error in the LSP.
+ */
+function todoBlock(type: string, label: string, rawSource: string): Element {
+  return el("TODO", [comment(`todo: ${label}`), valueEl("pre", rawSource)], {
+    type,
+  });
+}
+
+/** Build a <TODO> placeholder for unrecognized inline content, using <c> instead of <pre>. */
+function todoInline(type: string, label: string, rawSource: string): Element {
+  return el("TODO", [comment(`todo: ${label}`), valueEl("c", rawSource)], {
+    type,
+  });
 }
 
 /**
@@ -81,13 +122,13 @@ function nestListsInParagraphs(elements: Element[]): Element[] {
   const result: Element[] = [];
 
   for (const elem of elements) {
-    if (elem.name === 'ul' || elem.name === 'ol') {
-      if (result.length > 0 && result[result.length - 1]?.name === 'p') {
+    if (elem.name === "ul" || elem.name === "ol") {
+      if (result.length > 0 && result[result.length - 1]?.name === "p") {
         // Append list to preceding paragraph
         (result[result.length - 1].children as XastChild[]).push(elem);
       } else {
         // Wrap orphaned list in new <p>
-        result.push(el('p', [elem]));
+        result.push(el("p", [elem]));
       }
     } else {
       result.push(elem);
@@ -117,13 +158,16 @@ export function mdastToPtxast(tree: MdastRoot, source?: string): Root {
 export { mdastToPtxast as mdastToXast };
 
 /** Transform an mdast Root node, returning tree + diagnostic messages. */
-export function mdastToPtxastWithDiagnostics(tree: MdastRoot, source?: string): ConversionResult {
+export function mdastToPtxastWithDiagnostics(
+  tree: MdastRoot,
+  source?: string,
+): ConversionResult {
   const messages: ConversionMessage[] = [];
   const ctx: VisitContext = { ancestors: [], depth: 0, messages, source };
   const nodes = tree.children as Array<BlockContent | DefinitionContent>;
   const children = nestSections(nodes, ctx);
   return {
-    tree: { type: 'root', children: children as Root['children'] },
+    tree: { type: "root", children: children as Root["children"] },
     messages,
   };
 }
@@ -132,9 +176,20 @@ export function mdastToPtxastWithDiagnostics(tree: MdastRoot, source?: string): 
 // Section nesting
 // ---------------------------------------------------------------------------
 
-type DivType = 'chapter' | 'section' | 'subsection' | 'subsubsection' | 'paragraphs';
+type DivType =
+  | "chapter"
+  | "section"
+  | "subsection"
+  | "subsubsection"
+  | "paragraphs";
 
-const DEPTH_TO_TYPE: DivType[] = ['chapter', 'section', 'subsection', 'subsubsection', 'paragraphs'];
+const DEPTH_TO_TYPE: DivType[] = [
+  "chapter",
+  "section",
+  "subsection",
+  "subsubsection",
+  "paragraphs",
+];
 
 function depthToType(depth: number): DivType {
   return DEPTH_TO_TYPE[Math.min(depth - 1, DEPTH_TO_TYPE.length - 1)];
@@ -148,11 +203,12 @@ function depthToType(depth: number): DivType {
 function nestSections(
   nodes: Array<BlockContent | DefinitionContent>,
   ctx: VisitContext,
-  wrapOrphanedLists = false
+  wrapOrphanedLists = false,
 ): Element[] {
   let minDepth = 7;
   for (const node of nodes) {
-    if (node.type === 'heading') minDepth = Math.min(minDepth, (node as Heading).depth);
+    if (node.type === "heading")
+      minDepth = Math.min(minDepth, (node as Heading).depth);
   }
   if (minDepth === 7) {
     return convertBlockSequence(nodes, ctx, wrapOrphanedLists);
@@ -171,9 +227,11 @@ function nestSections(
   };
 
   for (const node of nodes) {
-    if (node.type === 'heading' && (node as Heading).depth === minDepth) {
+    if (node.type === "heading" && (node as Heading).depth === minDepth) {
       if (!currentHeading && preHeadingNodes.length > 0) {
-        result.push(...convertBlockSequence(preHeadingNodes, ctx, wrapOrphanedLists));
+        result.push(
+          ...convertBlockSequence(preHeadingNodes, ctx, wrapOrphanedLists),
+        );
         preHeadingNodes = [];
       }
       flushSection();
@@ -186,7 +244,9 @@ function nestSections(
     }
   }
   if (!currentHeading && preHeadingNodes.length > 0) {
-    result.push(...convertBlockSequence(preHeadingNodes, ctx, wrapOrphanedLists));
+    result.push(
+      ...convertBlockSequence(preHeadingNodes, ctx, wrapOrphanedLists),
+    );
   }
   flushSection();
   return result;
@@ -195,7 +255,7 @@ function nestSections(
 function convertBlockSequence(
   nodes: Array<BlockContent | DefinitionContent>,
   ctx: VisitContext,
-  wrapOrphanedLists = false
+  wrapOrphanedLists = false,
 ): Element[] {
   const result: Element[] = [];
 
@@ -207,19 +267,23 @@ function convertBlockSequence(
 
     // Fold display-math-only paragraphs into paragraph flow.
     if (
-      converted.name === 'p' &&
+      converted.name === "p" &&
       converted.children.length === 1 &&
-      (converted.children[0] as Element).name === 'md'
+      (converted.children[0] as Element).name === "md"
     ) {
       const md = converted.children[0] as Element;
       const prev = result[result.length - 1];
-      const nextConverted = i + 1 < nodes.length ? convertBlock(nodes[i + 1], ctx) : null;
-      const nextParagraphChildren = nextConverted?.name === 'p' ? nextConverted.children : null;
+      const nextConverted =
+        i + 1 < nodes.length ? convertBlock(nodes[i + 1], ctx) : null;
+      const nextParagraphChildren =
+        nextConverted?.name === "p" ? nextConverted.children : null;
 
-      if (prev?.name === 'p') {
+      if (prev?.name === "p") {
         (prev.children as XastChild[]).push(md);
         if (nextParagraphChildren) {
-          (prev.children as XastChild[]).push(...(nextParagraphChildren as XastChild[]));
+          (prev.children as XastChild[]).push(
+            ...(nextParagraphChildren as XastChild[]),
+          );
           i += 1;
         }
       } else {
@@ -228,16 +292,19 @@ function convertBlockSequence(
           children.push(...(nextParagraphChildren as XastChild[]));
           i += 1;
         }
-        result.push(el('p', children));
+        result.push(el("p", children));
       }
 
       continue;
     }
 
     // Nest lists inside preceding paragraphs (PreTeXt spec requires lists in <p> tags)
-    if ((converted.name === 'ul' || converted.name === 'ol') && result.length > 0) {
+    if (
+      (converted.name === "ul" || converted.name === "ol") &&
+      result.length > 0
+    ) {
       const prev = result[result.length - 1];
-      if (prev?.name === 'p') {
+      if (prev?.name === "p") {
         // Append list to preceding paragraph
         (prev.children as XastChild[]).push(converted);
         continue;
@@ -254,14 +321,18 @@ function convertBlockSequence(
 function buildDivision(
   heading: Heading,
   body: Array<BlockContent | DefinitionContent>,
-  ctx: VisitContext
+  ctx: VisitContext,
 ): Element {
   const divType = depthToType(heading.depth);
-  const titleEl = el('title', convertInlineNodes(heading.children, ctx));
+  const titleEl = el("title", convertInlineNodes(heading.children, ctx));
   const attrs = getHeadingAttrs(heading);
   // Inside divisions, orphaned lists need wrapping (wrapOrphanedLists=true)
-  const innerChildren = nestSections(body, { ...ctx, depth: ctx.depth + 1 }, true);
-  
+  const innerChildren = nestSections(
+    body,
+    { ...ctx, depth: ctx.depth + 1 },
+    true,
+  );
+
   // Also wrap orphaned lists that directly follow the title
   const wrappedChildren = nestListsInParagraphs(innerChildren);
 
@@ -270,7 +341,7 @@ function buildDivision(
 
 function getHeadingAttrs(heading: Heading): Record<string, string> | undefined {
   const data = heading.data as { id?: string } | undefined;
-  return data?.id ? { 'xml:id': data.id } : undefined;
+  return data?.id ? { "xml:id": data.id } : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -286,73 +357,99 @@ const blockHandlers: Record<
   blockquote: (node, ctx) => convertBlockquote(node as MdastBlockquote, ctx),
   list: (node, ctx) => convertList(node as List, ctx),
   code: (node, ctx) => convertCode(node as Code, ctx),
-  containerDirective: (node, ctx) => convertContainerDirective(node as ContainerDirective, ctx),
+  containerDirective: (node, ctx) =>
+    convertContainerDirective(node as ContainerDirective, ctx),
 };
 
-function convertBlock(node: BlockContent | DefinitionContent, ctx: VisitContext): Element | null {
+function convertBlock(
+  node: BlockContent | DefinitionContent,
+  ctx: VisitContext,
+): Element | null {
   const handler = blockHandlers[node.type];
 
   if (!handler) {
     if (ctx.messages) {
       ctx.messages.push({
-        type: 'warning',
+        type: "warning",
         reason: `Unknown block type: ${node.type}`,
-        category: 'unknown-block-type',
+        category: "unknown-block-type",
       });
     }
-    return null;
+    return todoBlock(
+      "unknown-block-type",
+      `unknown block type "${node.type}"`,
+      nodeSource(node, ctx),
+    );
   }
 
   return handler(node, ctx);
 }
 
 function convertParagraph(node: Paragraph, ctx: VisitContext): Element {
-  return el('p', convertInlineNodes(node.children, ctx));
+  return el("p", convertInlineNodes(node.children, ctx));
 }
 
 function convertBlockquote(node: MdastBlockquote, ctx: VisitContext): Element {
   const paragraphs = (node.children as Array<BlockContent | DefinitionContent>)
-    .filter((n): n is Paragraph => n.type === 'paragraph')
-    .map(n => {
+    .filter((n): n is Paragraph => n.type === "paragraph")
+    .map((n) => {
       // Pass blockquote as parent context for its paragraph children
-      const childCtx = { ...ctx, ancestors: [...ctx.ancestors, node], depth: ctx.depth + 1 };
+      const childCtx = {
+        ...ctx,
+        ancestors: [...ctx.ancestors, node],
+        depth: ctx.depth + 1,
+      };
       return convertParagraph(n, childCtx);
     });
-  return el('blockquote', paragraphs);
+  return el("blockquote", paragraphs);
 }
 
 function convertList(node: List, ctx: VisitContext): Element {
-  const items = node.children.map(child => {
-    const childCtx = { ...ctx, ancestors: [...ctx.ancestors, node], depth: ctx.depth + 1 };
+  const items = node.children.map((child) => {
+    const childCtx = {
+      ...ctx,
+      ancestors: [...ctx.ancestors, node],
+      depth: ctx.depth + 1,
+    };
     return convertListItem(child, childCtx);
   });
-  return el(node.ordered ? 'ol' : 'ul', items);
+  return el(node.ordered ? "ol" : "ul", items);
 }
 
 function convertListItem(node: ListItem, ctx: VisitContext): Element {
-  const children = convertBlockSequence(node.children as Array<BlockContent | DefinitionContent>, ctx);
-  return el('li', children);
+  const children = convertBlockSequence(
+    node.children as Array<BlockContent | DefinitionContent>,
+    ctx,
+  );
+  return el("li", children);
 }
 
 function convertCode(node: Code, ctx: VisitContext): Element {
-  return valueEl('program', node.value, node.lang ? { language: node.lang } : undefined);
+  return valueEl(
+    "program",
+    node.value,
+    node.lang ? { language: node.lang } : undefined,
+  );
 }
 
 function convertDisplayMath(node: CustomMath, ctx: VisitContext): Element {
   const rows = node.value
     .split(/\\\\|[\r\n]+/)
-    .map(line => line.trim())
-    .filter(line => line.length > 0);
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
 
   if (rows.length > 1) {
-    return el('md', rows.map(line => valueEl('mrow', line)));
+    return el(
+      "md",
+      rows.map((line) => valueEl("mrow", line)),
+    );
   }
-  return valueEl('md', rows[0] ?? '');
+  return valueEl("md", rows[0] ?? "");
 }
 
 function convertMathNode(node: CustomMath, ctx: VisitContext): Element | null {
-  if (node.meta === 'inline') {
-    return valueEl('m', node.value);
+  if (node.meta === "inline") {
+    return valueEl("m", node.value);
   }
   return convertDisplayMath(node, ctx);
 }
@@ -361,25 +458,41 @@ function convertMathNode(node: CustomMath, ctx: VisitContext): Element | null {
 // Container directive converters
 // ---------------------------------------------------------------------------
 
-function convertContainerDirective(node: ContainerDirective, ctx: VisitContext): Element | null {
+function convertContainerDirective(
+  node: ContainerDirective,
+  ctx: VisitContext,
+): Element | null {
   const spec = getDirectiveSpec(node.name);
 
   if (!spec) {
     if (ctx.messages) {
       ctx.messages.push({
-        type: 'warning',
+        type: "warning",
         reason: `Unknown directive: ${node.name}`,
-        category: 'unknown-directive',
+        category: "unknown-directive",
       });
     }
-    return null;
+    return todoBlock(
+      "unknown-directive",
+      `unknown directive "${node.name}"`,
+      nodeSource(node, ctx),
+    );
   }
 
   const attrs = buildDirectiveAttrs(node);
-  const directiveChildren = node.children as Array<BlockContent | DefinitionContent>;
-  const { title: titleEl, body } = extractDirectiveLabel(directiveChildren, ctx);
+  const directiveChildren = node.children as Array<
+    BlockContent | DefinitionContent
+  >;
+  const { title: titleEl, body } = extractDirectiveLabel(
+    directiveChildren,
+    ctx,
+  );
 
-  const childCtx = { ...ctx, ancestors: [...ctx.ancestors, node], depth: ctx.depth + 1 };
+  const childCtx = {
+    ...ctx,
+    ancestors: [...ctx.ancestors, node],
+    depth: ctx.depth + 1,
+  };
 
   // Phase 2: Use factory pattern - single function applies semantic rules from spec
   return buildDirectiveWithSpec(
@@ -389,7 +502,7 @@ function convertContainerDirective(node: ContainerDirective, ctx: VisitContext):
     body,
     childCtx,
     (child, ctx) => convertBlock(child, ctx),
-    (directive, ctx) => convertContainerDirective(directive, ctx)
+    (directive, ctx) => convertContainerDirective(directive, ctx),
   );
 }
 
@@ -402,23 +515,29 @@ function extractDirectiveLabel(
 } {
   const first = children[0];
   if (
-    first?.type === 'paragraph' &&
-    (first as Paragraph & { data?: { directiveLabel?: boolean } }).data?.directiveLabel === true
+    first?.type === "paragraph" &&
+    (first as Paragraph & { data?: { directiveLabel?: boolean } }).data
+      ?.directiveLabel === true
   ) {
     return {
-      title: el('title', convertInlineNodes((first as Paragraph).children, ctx)),
+      title: el(
+        "title",
+        convertInlineNodes((first as Paragraph).children, ctx),
+      ),
       body: children.slice(1),
     };
   }
   return { title: null, body: children };
 }
 
-function buildDirectiveAttrs(node: ContainerDirective): Record<string, string> | undefined {
+function buildDirectiveAttrs(
+  node: ContainerDirective,
+): Record<string, string> | undefined {
   const raw = node.attributes ?? {};
   const result: Record<string, string> = {};
   for (const [k, v] of Object.entries(raw)) {
     if (v == null) continue;
-    result[k === 'id' ? 'xml:id' : k] = v;
+    result[k === "id" ? "xml:id" : k] = v;
   }
   return Object.keys(result).length > 0 ? result : undefined;
 }
@@ -432,12 +551,19 @@ function buildDirectiveAttrs(node: ContainerDirective): Record<string, string> |
  * Returns 'underscore' or 'asterisk' based on the source text at the node's position.
  * If source is unavailable, defaults to 'asterisk' for backwards compatibility.
  */
-function getEmphasisDelimiter(node: Emphasis, source?: string): 'underscore' | 'asterisk' {
-  if (!source || node.position?.start?.offset === null || node.position?.start?.offset === undefined) {
-    return 'asterisk'; // default
+function getEmphasisDelimiter(
+  node: Emphasis,
+  source?: string,
+): "underscore" | "asterisk" {
+  if (
+    !source ||
+    node.position?.start?.offset === null ||
+    node.position?.start?.offset === undefined
+  ) {
+    return "asterisk"; // default
   }
   const delimiter = source.charAt(node.position.start.offset);
-  return delimiter === '_' ? 'underscore' : 'asterisk';
+  return delimiter === "_" ? "underscore" : "asterisk";
 }
 
 /** Dictionary of inline handlers. Maps node type → handler function. */
@@ -448,30 +574,43 @@ const inlineHandlers: Record<
   text: (node, ctx) => text((node as Text).value),
   emphasis: (node, ctx) => {
     const delim = getEmphasisDelimiter(node as Emphasis, ctx.source);
-    const tag = delim === 'underscore' ? 'term' : 'em';
+    const tag = delim === "underscore" ? "term" : "em";
     return el(tag, convertInlineNodes((node as Emphasis).children, ctx));
   },
-  strong: (node, ctx) => el('alert', convertInlineNodes((node as Strong).children, ctx)),
-  inlineCode: (node, ctx) => valueEl('c', (node as InlineCode).value),
+  strong: (node, ctx) =>
+    el("alert", convertInlineNodes((node as Strong).children, ctx)),
+  inlineCode: (node, ctx) => valueEl("c", (node as InlineCode).value),
   math: (node, ctx) => convertMathNode(node as unknown as CustomMath, ctx),
 };
 
-function convertInlineNodes(nodes: PhrasingContent[], ctx: VisitContext): XastChild[] {
-  return nodes.flatMap(node => convertInline(node, ctx)).filter((n): n is XastChild => n !== null);
+function convertInlineNodes(
+  nodes: PhrasingContent[],
+  ctx: VisitContext,
+): XastChild[] {
+  return nodes
+    .flatMap((node) => convertInline(node, ctx))
+    .filter((n): n is XastChild => n !== null);
 }
 
-function convertInline(node: PhrasingContent, ctx: VisitContext): XastChild | null {
+function convertInline(
+  node: PhrasingContent,
+  ctx: VisitContext,
+): XastChild | null {
   const handler = inlineHandlers[node.type];
 
   if (!handler) {
     if (ctx.messages) {
       ctx.messages.push({
-        type: 'warning',
+        type: "warning",
         reason: `Unknown inline type: ${node.type}`,
-        category: 'unknown-inline-type',
+        category: "unknown-inline-type",
       });
     }
-    return null;
+    return todoInline(
+      "unknown-inline-type",
+      `unknown inline type "${node.type}"`,
+      nodeSource(node, ctx),
+    );
   }
 
   // Pass context with this node added to ancestors, but parent unchanged

--- a/packages/remark-pretext/src/lib/remark-pretext.spec.ts
+++ b/packages/remark-pretext/src/lib/remark-pretext.spec.ts
@@ -1,16 +1,16 @@
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkDirective from 'remark-directive';
-import { describe, it, expect } from 'vitest';
-import { remarkPretext, mdastToPtxast } from '../index.js';
-import remarkMath from './math-parser.js';
-import { mdastToPtxastWithDiagnostics } from './mdast-to-ptxast.js';
-import { normalizeDirectiveColons } from './directive-normalizer.js';
-import type { Element, Root, Text as XastText } from 'xast';
-import { toXml } from 'xast-util-to-xml';
-import { fromXml } from 'xast-util-from-xml';
-import { getPtxTextContent } from '@pretextbook/ptxast';
-import type { Root as MdastRoot } from 'mdast';
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkDirective from "remark-directive";
+import { describe, it, expect } from "vitest";
+import { remarkPretext, mdastToPtxast } from "../index.js";
+import remarkMath from "./math-parser.js";
+import { mdastToPtxastWithDiagnostics } from "./mdast-to-ptxast.js";
+import { normalizeDirectiveColons } from "./directive-normalizer.js";
+import type { Element, Root, Text as XastText } from "xast";
+import { toXml } from "xast-util-to-xml";
+import { fromXml } from "xast-util-from-xml";
+import { getPtxTextContent } from "@pretextbook/ptxast";
+import type { Root as MdastRoot } from "mdast";
 
 /** Helper: parse markdown and transform to xast Root. */
 function parse(md: string): Root {
@@ -29,11 +29,11 @@ function parseWithDiagnostics(md: string) {
 }
 
 function elName(node: unknown): string {
-  return (node as Element).name ?? '';
+  return (node as Element).name ?? "";
 }
 
 function textValue(node: unknown): string {
-  return ((node as XastText).value) ?? '';
+  return (node as XastText).value ?? "";
 }
 
 /** Count occurrences of each element name in the xast tree (plus 'root' and 'text'). */
@@ -42,15 +42,19 @@ function nodeNameCounts(root: Root): Record<string, number> {
   const stack: unknown[] = [root];
 
   while (stack.length > 0) {
-    const current = stack.pop() as { type?: unknown; name?: unknown; children?: unknown };
-    if (!current || typeof current !== 'object') continue;
+    const current = stack.pop() as {
+      type?: unknown;
+      name?: unknown;
+      children?: unknown;
+    };
+    if (!current || typeof current !== "object") continue;
 
-    if (current.type === 'element' && typeof current.name === 'string') {
+    if (current.type === "element" && typeof current.name === "string") {
       counts[current.name] = (counts[current.name] ?? 0) + 1;
-    } else if (current.type === 'text') {
-      counts['text'] = (counts['text'] ?? 0) + 1;
-    } else if (current.type === 'root') {
-      counts['root'] = (counts['root'] ?? 0) + 1;
+    } else if (current.type === "text") {
+      counts["text"] = (counts["text"] ?? 0) + 1;
+    } else if (current.type === "root") {
+      counts["root"] = (counts["root"] ?? 0) + 1;
     }
 
     if (Array.isArray(current.children)) {
@@ -63,346 +67,369 @@ function nodeNameCounts(root: Root): Record<string, number> {
   return counts;
 }
 
-describe('paragraph conversion', () => {
-  it('converts a paragraph to a p element', () => {
-    const tree = parse('Hello world.');
-    expect(tree.type).toBe('root');
+describe("paragraph conversion", () => {
+  it("converts a paragraph to a p element", () => {
+    const tree = parse("Hello world.");
+    expect(tree.type).toBe("root");
     expect(tree.children).toHaveLength(1);
-    expect(elName(tree.children[0])).toBe('p');
+    expect(elName(tree.children[0])).toBe("p");
   });
 
-  it('p element contains text children', () => {
-    const tree = parse('Hello world.');
+  it("p element contains text children", () => {
+    const tree = parse("Hello world.");
     const p = tree.children[0] as Element;
-    expect(p.children[0]).toEqual({ type: 'text', value: 'Hello world.' });
+    expect(p.children[0]).toEqual({ type: "text", value: "Hello world." });
   });
 
-  it('converts multiple paragraphs', () => {
-    const tree = parse('First.\n\nSecond.');
+  it("converts multiple paragraphs", () => {
+    const tree = parse("First.\n\nSecond.");
     expect(tree.children).toHaveLength(2);
-    expect(elName(tree.children[0])).toBe('p');
-    expect(elName(tree.children[1])).toBe('p');
+    expect(elName(tree.children[0])).toBe("p");
+    expect(elName(tree.children[1])).toBe("p");
   });
 });
 
-describe('inline element conversion', () => {
-  it('emphasis  em', () => {
-    const tree = parse('*italic*');
+describe("inline element conversion", () => {
+  it("emphasis  em", () => {
+    const tree = parse("*italic*");
     const p = tree.children[0] as Element;
     const em = p.children[0] as Element;
-    expect(elName(em)).toBe('em');
-    expect(textValue(em.children[0])).toBe('italic');
+    expect(elName(em)).toBe("em");
+    expect(textValue(em.children[0])).toBe("italic");
   });
 
-  it('underline emphasis  term', () => {
-    const tree = parse('_underlined_');
+  it("underline emphasis  term", () => {
+    const tree = parse("_underlined_");
     const p = tree.children[0] as Element;
     const term = p.children[0] as Element;
-    expect(elName(term)).toBe('term');
-    expect(textValue(term.children[0])).toBe('underlined');
+    expect(elName(term)).toBe("term");
+    expect(textValue(term.children[0])).toBe("underlined");
   });
 
-  it('mixed emphasis in single paragraph', () => {
-    const tree = parse('Here is *italic* and _term_ and **bold**.');
+  it("mixed emphasis in single paragraph", () => {
+    const tree = parse("Here is *italic* and _term_ and **bold**.");
     const p = tree.children[0] as Element;
-    const elements = p.children.filter(n => typeof n === 'object' && n.type === 'element') as Element[];
-    
-    const em = elements.find(e => e.name === 'em');
-    const term = elements.find(e => e.name === 'term');
-    const alert = elements.find(e => e.name === 'alert');
-    
+    const elements = p.children.filter(
+      (n) => typeof n === "object" && n.type === "element",
+    ) as Element[];
+
+    const em = elements.find((e) => e.name === "em");
+    const term = elements.find((e) => e.name === "term");
+    const alert = elements.find((e) => e.name === "alert");
+
     expect(em).toBeDefined();
-    expect(textValue(em!.children[0])).toBe('italic');
+    expect(textValue(em!.children[0])).toBe("italic");
     expect(term).toBeDefined();
-    expect(textValue(term!.children[0])).toBe('term');
+    expect(textValue(term!.children[0])).toBe("term");
     expect(alert).toBeDefined();
-    expect(textValue(alert!.children[0])).toBe('bold');
+    expect(textValue(alert!.children[0])).toBe("bold");
   });
 
-  it('strong  alert', () => {
-    const tree = parse('**bold**');
+  it("strong  alert", () => {
+    const tree = parse("**bold**");
     const p = tree.children[0] as Element;
     const alert = p.children[0] as Element;
-    expect(elName(alert)).toBe('alert');
-    expect(textValue(alert.children[0])).toBe('bold');
+    expect(elName(alert)).toBe("alert");
+    expect(textValue(alert.children[0])).toBe("bold");
   });
 
-  it('inlineCode  c', () => {
-    const tree = parse('Use `x := 0`.');
+  it("inlineCode  c", () => {
+    const tree = parse("Use `x := 0`.");
     const p = tree.children[0] as Element;
-    const c = p.children.find(n => elName(n) === 'c') as Element;
-    expect(elName(c)).toBe('c');
-    expect(getPtxTextContent(c)).toBe('x := 0');
+    const c = p.children.find((n) => elName(n) === "c") as Element;
+    expect(elName(c)).toBe("c");
+    expect(getPtxTextContent(c)).toBe("x := 0");
   });
 
-  it('inline math  m', () => {
-    const tree = parse('Let $x^2 + 1$.');
+  it("inline math  m", () => {
+    const tree = parse("Let $x^2 + 1$.");
     const p = tree.children[0] as Element;
-    const m = p.children.find(n => elName(n) === 'm') as Element;
-    expect(elName(m)).toBe('m');
-    expect(getPtxTextContent(m)).toBe('x^2 + 1');
+    const m = p.children.find((n) => elName(n) === "m") as Element;
+    expect(elName(m)).toBe("m");
+    expect(getPtxTextContent(m)).toBe("x^2 + 1");
   });
 });
 
-describe('display math', () => {
-  it('display math is placed in a paragraph as md', () => {
-    const tree = parse('$$\na^2 + b^2 = c^2\n$$');
-    expect(elName(tree.children[0])).toBe('p');
+describe("display math", () => {
+  it("display math is placed in a paragraph as md", () => {
+    const tree = parse("$$\na^2 + b^2 = c^2\n$$");
+    expect(elName(tree.children[0])).toBe("p");
     const p = tree.children[0] as Element;
     const md = p.children[0] as Element;
-    expect(elName(md)).toBe('md');
+    expect(elName(md)).toBe("md");
     // Single-line display math: first child is a Text node
-    expect(md.children[0].type).toBe('text');
-    expect(getPtxTextContent(md)).toBe('a^2 + b^2 = c^2');
+    expect(md.children[0].type).toBe("text");
+    expect(getPtxTextContent(md)).toBe("a^2 + b^2 = c^2");
   });
 
-  it('display math joins previous and next paragraphs', () => {
-    const tree = parse('Before.\n\n$$\na^2 + b^2 = c^2\n$$\n\nAfter.');
+  it("display math joins previous and next paragraphs", () => {
+    const tree = parse("Before.\n\n$$\na^2 + b^2 = c^2\n$$\n\nAfter.");
     expect(tree.children).toHaveLength(1);
     const p = tree.children[0] as Element;
-    expect(elName(p)).toBe('p');
-    expect(textValue(p.children[0])).toBe('Before.');
+    expect(elName(p)).toBe("p");
+    expect(textValue(p.children[0])).toBe("Before.");
     const md = p.children[1] as Element;
-    expect(elName(md)).toBe('md');
-    expect(md.children[0].type).toBe('text');
-    expect(getPtxTextContent(md)).toBe('a^2 + b^2 = c^2');
-    expect(textValue(p.children[2])).toBe('After.');
+    expect(elName(md)).toBe("md");
+    expect(md.children[0].type).toBe("text");
+    expect(getPtxTextContent(md)).toBe("a^2 + b^2 = c^2");
+    expect(textValue(p.children[2])).toBe("After.");
   });
 
-  it('multi-line display math renders as mrows', () => {
-    const tree = parse('$$\na^2\nb^2\nc^2\n$$');
-    expect(elName(tree.children[0])).toBe('p');
+  it("multi-line display math renders as mrows", () => {
+    const tree = parse("$$\na^2\nb^2\nc^2\n$$");
+    expect(elName(tree.children[0])).toBe("p");
     const p = tree.children[0] as Element;
     const md = p.children[0] as Element;
-    expect(elName(md)).toBe('md');
+    expect(elName(md)).toBe("md");
     // Multi-line: children are mrow elements
     expect(md.children.length).toBe(3);
-    expect(elName(md.children[0])).toBe('mrow');
-    expect(getPtxTextContent(md.children[0] as Element)).toBe('a^2');
-    expect(getPtxTextContent(md.children[1] as Element)).toBe('b^2');
-    expect(getPtxTextContent(md.children[2] as Element)).toBe('c^2');
+    expect(elName(md.children[0])).toBe("mrow");
+    expect(getPtxTextContent(md.children[0] as Element)).toBe("a^2");
+    expect(getPtxTextContent(md.children[1] as Element)).toBe("b^2");
+    expect(getPtxTextContent(md.children[2] as Element)).toBe("c^2");
   });
 
-  it('empty display math produces an md element with empty text child', () => {
-    const tree = parse('$$ $$');
+  it("empty display math produces an md element with empty text child", () => {
+    const tree = parse("$$ $$");
     const p = tree.children[0] as Element;
-    const md = p.children.find(n => elName(n) === 'md') as Element;
+    const md = p.children.find((n) => elName(n) === "md") as Element;
     expect(md).toBeDefined();
-    expect(elName(md)).toBe('md');
-    expect(getPtxTextContent(md)).toBe('');
+    expect(elName(md)).toBe("md");
+    expect(getPtxTextContent(md)).toBe("");
   });
 
-  it('inline code containing $ is not treated as math', () => {
-    const tree = parse('Use `$x$` here.');
+  it("inline code containing $ is not treated as math", () => {
+    const tree = parse("Use `$x$` here.");
     const p = tree.children[0] as Element;
-    const c = p.children.find(n => elName(n) === 'c') as Element;
+    const c = p.children.find((n) => elName(n) === "c") as Element;
     expect(c).toBeDefined();
-    expect(getPtxTextContent(c)).toBe('$x$');
-    expect(p.children.some(n => elName(n) === 'm' || elName(n) === 'md')).toBe(false);
+    expect(getPtxTextContent(c)).toBe("$x$");
+    expect(
+      p.children.some((n) => elName(n) === "m" || elName(n) === "md"),
+    ).toBe(false);
   });
 
-  it('inline $$ delimiters create display math (custom parser)', () => {
-    const tree = parse('Text $$a^2+b^2=c^2$$ more text');
+  it("inline $$ delimiters create display math (custom parser)", () => {
+    const tree = parse("Text $$a^2+b^2=c^2$$ more text");
     const p = tree.children[0] as Element;
-    const hasMath = p.children.some(child => elName(child) === 'md');
+    const hasMath = p.children.some((child) => elName(child) === "md");
     expect(hasMath).toBe(true);
-    const md = p.children.find(child => elName(child) === 'md') as Element;
-    expect(elName(md)).toBe('md');
-    expect(md.children[0].type).toBe('text');
-    expect(getPtxTextContent(md)).toBe('a^2+b^2=c^2');
+    const md = p.children.find((child) => elName(child) === "md") as Element;
+    expect(elName(md)).toBe("md");
+    expect(md.children[0].type).toBe("text");
+    expect(getPtxTextContent(md)).toBe("a^2+b^2=c^2");
   });
 
-  it('LaTeX \\[...\\] delimiters are converted to display math', () => {
-    const tree = parse('\\[a^2+b^2=c^2\\]');
-    expect(elName(tree.children[0])).toBe('p');
+  it("LaTeX \\[...\\] delimiters are converted to display math", () => {
+    const tree = parse("\\[a^2+b^2=c^2\\]");
+    expect(elName(tree.children[0])).toBe("p");
     const p = tree.children[0] as Element;
     const md = p.children[0] as Element;
-    expect(elName(md)).toBe('md');
-    expect(md.children[0].type).toBe('text');
-    expect(getPtxTextContent(md)).toBe('a^2+b^2=c^2');
+    expect(elName(md)).toBe("md");
+    expect(md.children[0].type).toBe("text");
+    expect(getPtxTextContent(md)).toBe("a^2+b^2=c^2");
   });
 
-  it('LaTeX \\[...\\] with multiple lines creates mrows', () => {
-    const tree = parse('\\[\na^2\nb^2\nc^2\n\\]');
+  it("LaTeX \\[...\\] with multiple lines creates mrows", () => {
+    const tree = parse("\\[\na^2\nb^2\nc^2\n\\]");
     const p = tree.children[0] as Element;
     const md = p.children[0] as Element;
-    expect(elName(md)).toBe('md');
+    expect(elName(md)).toBe("md");
     expect(md.children.length).toBe(3);
-    expect(elName(md.children[0])).toBe('mrow');
-    expect(getPtxTextContent(md.children[0] as Element)).toBe('a^2');
-    expect(getPtxTextContent(md.children[1] as Element)).toBe('b^2');
-    expect(getPtxTextContent(md.children[2] as Element)).toBe('c^2');
+    expect(elName(md.children[0])).toBe("mrow");
+    expect(getPtxTextContent(md.children[0] as Element)).toBe("a^2");
+    expect(getPtxTextContent(md.children[1] as Element)).toBe("b^2");
+    expect(getPtxTextContent(md.children[2] as Element)).toBe("c^2");
   });
 
-  it('LaTeX \\(...\\) delimiters are converted to inline math', () => {
-    const tree = parse('Text \\(x^2\\) more text');
+  it("LaTeX \\(...\\) delimiters are converted to inline math", () => {
+    const tree = parse("Text \\(x^2\\) more text");
     const p = tree.children[0] as Element;
-    const hasInlineMath = p.children.some(child => elName(child) === 'm');
+    const hasInlineMath = p.children.some((child) => elName(child) === "m");
     expect(hasInlineMath).toBe(true);
-    const m = p.children.find(child => elName(child) === 'm') as Element;
-    expect(elName(m)).toBe('m');
-    expect(getPtxTextContent(m)).toBe('x^2');
+    const m = p.children.find((child) => elName(child) === "m") as Element;
+    expect(elName(m)).toBe("m");
+    expect(getPtxTextContent(m)).toBe("x^2");
   });
 });
 
-describe('list conversion', () => {
-  it('unordered list  ul with li children', () => {
-    const tree = parse('- alpha\n- beta\n- gamma');
+describe("list conversion", () => {
+  it("unordered list  ul with li children", () => {
+    const tree = parse("- alpha\n- beta\n- gamma");
     const ul = tree.children[0] as Element;
-    expect(elName(ul)).toBe('ul');
+    expect(elName(ul)).toBe("ul");
     expect(ul.children).toHaveLength(3);
-    expect(elName(ul.children[0])).toBe('li');
+    expect(elName(ul.children[0])).toBe("li");
   });
 
-  it('ordered list  ol', () => {
-    const tree = parse('1. first\n2. second');
+  it("ordered list  ol", () => {
+    const tree = parse("1. first\n2. second");
     const ol = tree.children[0] as Element;
-    expect(elName(ol)).toBe('ol');
+    expect(elName(ol)).toBe("ol");
     expect(ol.children).toHaveLength(2);
   });
 
-  it('li children contain p elements', () => {
-    const tree = parse('- item text');
+  it("li children contain p elements", () => {
+    const tree = parse("- item text");
     const ul = tree.children[0] as Element;
     const li = ul.children[0] as Element;
-    expect(elName(li)).toBe('li');
-    expect(elName(li.children[0])).toBe('p');
+    expect(elName(li)).toBe("li");
+    expect(elName(li.children[0])).toBe("p");
   });
 });
 
-describe('heading  section nesting', () => {
-  it('## heading  section with title', () => {
-    const tree = parse('## My Section\n\nSome text.');
+describe("heading  section nesting", () => {
+  it("## heading  section with title", () => {
+    const tree = parse("## My Section\n\nSome text.");
     const section = tree.children[0] as Element;
-    expect(elName(section)).toBe('section');
+    expect(elName(section)).toBe("section");
     const title = section.children[0] as Element;
-    expect(elName(title)).toBe('title');
-    expect(textValue(title.children[0])).toBe('My Section');
+    expect(elName(title)).toBe("title");
+    expect(textValue(title.children[0])).toBe("My Section");
   });
 
-  it('section body contains converted blocks', () => {
-    const tree = parse('## My Section\n\nA paragraph.');
+  it("section body contains converted blocks", () => {
+    const tree = parse("## My Section\n\nA paragraph.");
     const section = tree.children[0] as Element;
-    expect(elName(section.children[1])).toBe('p');
+    expect(elName(section.children[1])).toBe("p");
   });
 
-  it('# heading  chapter', () => {
-    const tree = parse('# Chapter One\n\nText.');
-    expect(elName(tree.children[0])).toBe('chapter');
+  it("# heading  chapter", () => {
+    const tree = parse("# Chapter One\n\nText.");
+    expect(elName(tree.children[0])).toBe("chapter");
   });
 
-  it('### heading  subsection', () => {
-    const tree = parse('### Deep\n\nText.');
-    expect(elName(tree.children[0])).toBe('subsection');
+  it("### heading  subsection", () => {
+    const tree = parse("### Deep\n\nText.");
+    expect(elName(tree.children[0])).toBe("subsection");
   });
 
-  it('section contains subsection from deeper heading', () => {
-    const tree = parse('## Section\n\n### Subsection\n\nText.');
+  it("section contains subsection from deeper heading", () => {
+    const tree = parse("## Section\n\n### Subsection\n\nText.");
     const section = tree.children[0] as Element;
-    expect(section.children.some(c => elName(c) === 'subsection')).toBe(true);
+    expect(section.children.some((c) => elName(c) === "subsection")).toBe(true);
   });
 
-  it('content before any heading is a direct child of root', () => {
-    const tree = parse('Intro text.\n\n## Section\n\nBody.');
-    expect(elName(tree.children[0])).toBe('p');
-    expect(elName(tree.children[1])).toBe('section');
+  it("content before any heading is a direct child of root", () => {
+    const tree = parse("Intro text.\n\n## Section\n\nBody.");
+    expect(elName(tree.children[0])).toBe("p");
+    expect(elName(tree.children[1])).toBe("section");
   });
 });
 
-describe('container directives', () => {
-  it(':::theorem directive  theorem element', () => {
-    const tree = parse(':::theorem\nStatement text.\n:::');
+describe("container directives", () => {
+  it(":::theorem directive  theorem element", () => {
+    const tree = parse(":::theorem\nStatement text.\n:::");
     const thm = tree.children[0] as Element;
-    expect(elName(thm)).toBe('theorem');
+    expect(elName(thm)).toBe("theorem");
   });
 
-  it('theorem body is wrapped in a statement element', () => {
-    const tree = parse(':::theorem\nStatement text.\n:::');
+  it("theorem body is wrapped in a statement element", () => {
+    const tree = parse(":::theorem\nStatement text.\n:::");
     const thm = tree.children[0] as Element;
     const stmt = thm.children[0] as Element;
-    expect(elName(stmt)).toBe('statement');
-    expect(elName(stmt.children[0])).toBe('p');
+    expect(elName(stmt)).toBe("statement");
+    expect(elName(stmt.children[0])).toBe("p");
   });
 
-  it('theorem title from directive label', () => {
-    const tree = parse(':::theorem[Pythagoras]\nFor right triangles.\n:::');
+  it("theorem title from directive label", () => {
+    const tree = parse(":::theorem[Pythagoras]\nFor right triangles.\n:::");
     const thm = tree.children[0] as Element;
     const title = thm.children[0] as Element;
-    expect(elName(title)).toBe('title');
-    expect(textValue(title.children[0])).toBe('Pythagoras');
+    expect(elName(title)).toBe("title");
+    expect(textValue(title.children[0])).toBe("Pythagoras");
   });
 
-  it(':::theorem with xml:id attribute from {#id}', () => {
-    const tree = parse(':::theorem{#thm-pyth}\nText.\n:::');
+  it(":::theorem with xml:id attribute from {#id}", () => {
+    const tree = parse(":::theorem{#thm-pyth}\nText.\n:::");
     const thm = tree.children[0] as Element;
-    expect(thm.attributes?.['xml:id']).toBe('thm-pyth');
+    expect(thm.attributes?.["xml:id"]).toBe("thm-pyth");
   });
 
-  it('nested :::proof inside :::theorem becomes a proof child', () => {
+  it("nested :::proof inside :::theorem becomes a proof child", () => {
     const tree = parse(
-      ':::theorem\nStatement.\n\n:::proof\nProof body.\n:::\n:::'
+      ":::theorem\nStatement.\n\n:::proof\nProof body.\n:::\n:::",
     );
     const thm = tree.children[0] as Element;
-    const proof = thm.children.find(c => elName(c) === 'proof') as Element;
+    const proof = thm.children.find((c) => elName(c) === "proof") as Element;
     expect(proof).toBeDefined();
-    expect(elName(proof)).toBe('proof');
-    expect(elName(proof.children[0])).toBe('p');
+    expect(elName(proof)).toBe("proof");
+    expect(elName(proof.children[0])).toBe("p");
   });
 
-  it(':::definition directive  definition element', () => {
-    const tree = parse(':::definition\nA function.\n:::');
-    expect(elName(tree.children[0])).toBe('definition');
+  it(":::definition directive  definition element", () => {
+    const tree = parse(":::definition\nA function.\n:::");
+    expect(elName(tree.children[0])).toBe("definition");
   });
 
-  it(':::remark directive  remark element', () => {
-    const tree = parse(':::remark\nA remark.\n:::');
-    expect(elName(tree.children[0])).toBe('remark');
+  it(":::remark directive  remark element", () => {
+    const tree = parse(":::remark\nA remark.\n:::");
+    expect(elName(tree.children[0])).toBe("remark");
   });
 
-  it(':::example directive  example element', () => {
-    const tree = parse(':::example\nAn example.\n:::');
-    expect(elName(tree.children[0])).toBe('example');
+  it(":::example directive  example element", () => {
+    const tree = parse(":::example\nAn example.\n:::");
+    expect(elName(tree.children[0])).toBe("example");
   });
 
-  it(':::proof directive  proof element', () => {
-    const tree = parse(':::proof\nTrivial.\n:::');
-    expect(elName(tree.children[0])).toBe('proof');
+  it(":::proof directive  proof element", () => {
+    const tree = parse(":::proof\nTrivial.\n:::");
+    expect(elName(tree.children[0])).toBe("proof");
   });
 
-  it('unknown directive is dropped (returns null)', () => {
-    const tree = parse(':::unknownblock\nContent.\n:::');
-    expect(tree.children).toHaveLength(0);
+  it("unknown directive is preserved as a <TODO> placeholder", () => {
+    const tree = parse(":::unknownblock\nContent.\n:::");
+    expect(tree.children).toHaveLength(1);
+    expect(elName(tree.children[0])).toBe("TODO");
+    const todo = tree.children[0] as Element;
+    expect(todo.attributes?.["type"]).toBe("unknown-directive");
+    // first child is the <!-- todo: ... --> comment
+    expect(todo.children[0]?.type).toBe("comment");
+    // second child is <pre> with raw source
+    expect(elName(todo.children[1] as Element)).toBe("pre");
   });
 });
 
-describe('mdastToPtxast standalone function', () => {
-  it('accepts an mdast Root and returns an xast Root', () => {
-    const processor = unified().use(remarkParse).use(remarkDirective).use(remarkMath);
-    const mdast = processor.parse('Hello.') as MdastRoot;
+describe("mdastToPtxast standalone function", () => {
+  it("accepts an mdast Root and returns an xast Root", () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .use(remarkMath);
+    const mdast = processor.parse("Hello.") as MdastRoot;
     const ptx = mdastToPtxast(mdast);
-    expect(ptx.type).toBe('root');
-    expect(elName(ptx.children[0])).toBe('p');
+    expect(ptx.type).toBe("root");
+    expect(elName(ptx.children[0])).toBe("p");
   });
 });
 
-describe('semantic round-trip (markdown -> xast -> xml -> xast)', () => {
-  it('preserves structure for representative markdown fixtures', () => {
+describe("semantic round-trip (markdown -> xast -> xml -> xast)", () => {
+  it("preserves structure for representative markdown fixtures", () => {
     const fixtures = [
       {
-        name: 'section + theorem + proof + list + math',
+        name: "section + theorem + proof + list + math",
         markdown:
-          '## Section One\n\n:::theorem[Main]{#thm-main}\nStatement with $x^2$.\n\n:::proof\nProof text.\n:::\n:::\n\n1. first\n2. second',
-        requiredNames: ['section', 'title', 'theorem', 'statement', 'proof', 'ol', 'li', 'm'],
+          "## Section One\n\n:::theorem[Main]{#thm-main}\nStatement with $x^2$.\n\n:::proof\nProof text.\n:::\n:::\n\n1. first\n2. second",
+        requiredNames: [
+          "section",
+          "title",
+          "theorem",
+          "statement",
+          "proof",
+          "ol",
+          "li",
+          "m",
+        ],
       },
       {
-        name: 'chapter with subsection and display math',
-        markdown: '# Chapter A\n\n### Sub A\n\n$$\na^2+b^2=c^2\n$$\n',
-        requiredNames: ['chapter', 'subsection', 'title', 'md'],
+        name: "chapter with subsection and display math",
+        markdown: "# Chapter A\n\n### Sub A\n\n$$\na^2+b^2=c^2\n$$\n",
+        requiredNames: ["chapter", "subsection", "title", "md"],
       },
       {
-        name: 'inline formatting paragraph',
-        markdown: 'A paragraph with *emphasis*, **alert**, and `code`.',
-        requiredNames: ['p', 'em', 'alert', 'c'],
+        name: "inline formatting paragraph",
+        markdown: "A paragraph with *emphasis*, **alert**, and `code`.",
+        requiredNames: ["p", "em", "alert", "c"],
       },
     ];
 
@@ -415,94 +442,95 @@ describe('semantic round-trip (markdown -> xast -> xml -> xast)', () => {
       const after = nodeNameCounts(reparsed);
 
       for (const name of fixture.requiredNames) {
-        expect(after[name], `${fixture.name}: missing ${name} after xml round-trip`).toBe(
-          before[name],
-        );
+        expect(
+          after[name],
+          `${fixture.name}: missing ${name} after xml round-trip`,
+        ).toBe(before[name]);
       }
     }
   });
 });
 
-  // Task support tests
-  describe('tasks with nested structure', () => {
-    it(':::task directive creates task element', () => {
-      const tree = parse(':::task\nTask content.\n:::');
-      const task = tree.children[0] as Element;
-      expect(elName(task)).toBe('task');
-    });
+// Task support tests
+describe("tasks with nested structure", () => {
+  it(":::task directive creates task element", () => {
+    const tree = parse(":::task\nTask content.\n:::");
+    const task = tree.children[0] as Element;
+    expect(elName(task)).toBe("task");
+  });
 
-    it('task without nested tasks wraps content in statement', () => {
-      const tree = parse(':::task\nTask content.\n:::');
-      const task = tree.children[0] as Element;
-      const stmt = task.children[0] as Element;
-      expect(elName(stmt)).toBe('statement');
-      expect(elName(stmt.children[0])).toBe('p');
-    });
+  it("task without nested tasks wraps content in statement", () => {
+    const tree = parse(":::task\nTask content.\n:::");
+    const task = tree.children[0] as Element;
+    const stmt = task.children[0] as Element;
+    expect(elName(stmt)).toBe("statement");
+    expect(elName(stmt.children[0])).toBe("p");
+  });
 
-    it('exercise with nested tasks creates introduction from intro content', () => {
-      const md = `:::exercise
+  it("exercise with nested tasks creates introduction from intro content", () => {
+    const md = `:::exercise
 Exercise intro text.
 
 :::task
 Task 1 content.
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      // First child should be introduction
-      const intro = exercise.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      // Check intro contains the text
-      if (intro.children[0]) {
-        const introP = intro.children[0] as Element;
-        expect(elName(introP)).toBe('p');
-        // Get text from first child of the paragraph
-        if (introP.children[0]) {
-          expect(textValue(introP.children[0])).toBe('Exercise intro text.');
-        }
-      }
-      
-      // Following child should be the task
-      if (exercise.children[1]) {
-        const task1 = exercise.children[1] as Element;
-        expect(elName(task1)).toBe('task');
-        // Tasks that don't have nested tasks get wrapped in statement
-        const firstChild = task1.children[0] as Element;
-        if (elName(firstChild) === 'statement') {
-          // Content is inside statement, then p element
-          const p = firstChild.children[0] as Element;
-          expect(elName(p)).toBe('p');
-          expect(textValue(p.children[0])).toBe('Task 1 content.');
-        }
-      }
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('task with nested task creates introduction wrapper', () => {
-      const md = `:::task
+    // First child should be introduction
+    const intro = exercise.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    // Check intro contains the text
+    if (intro.children[0]) {
+      const introP = intro.children[0] as Element;
+      expect(elName(introP)).toBe("p");
+      // Get text from first child of the paragraph
+      if (introP.children[0]) {
+        expect(textValue(introP.children[0])).toBe("Exercise intro text.");
+      }
+    }
+
+    // Following child should be the task
+    if (exercise.children[1]) {
+      const task1 = exercise.children[1] as Element;
+      expect(elName(task1)).toBe("task");
+      // Tasks that don't have nested tasks get wrapped in statement
+      const firstChild = task1.children[0] as Element;
+      if (elName(firstChild) === "statement") {
+        // Content is inside statement, then p element
+        const p = firstChild.children[0] as Element;
+        expect(elName(p)).toBe("p");
+        expect(textValue(p.children[0])).toBe("Task 1 content.");
+      }
+    }
+  });
+
+  it("task with nested task creates introduction wrapper", () => {
+    const md = `:::task
 Task intro text.
 
 :::task
 Nested task content.
 :::
 :::`;
-      const tree = parse(md);
-      const parentTask = tree.children[0] as Element;
-      expect(elName(parentTask)).toBe('task');
-      
-      // First child should be introduction
-      const intro = parentTask.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      // Second child should be nested task
-      const nestedTask = parentTask.children[1] as Element;
-      expect(elName(nestedTask)).toBe('task');
-    });
+    const tree = parse(md);
+    const parentTask = tree.children[0] as Element;
+    expect(elName(parentTask)).toBe("task");
 
-    it('exercise with no intro content and nested tasks starts with task', () => {
-      const md = `:::exercise
+    // First child should be introduction
+    const intro = parentTask.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    // Second child should be nested task
+    const nestedTask = parentTask.children[1] as Element;
+    expect(elName(nestedTask)).toBe("task");
+  });
+
+  it("exercise with no intro content and nested tasks starts with task", () => {
+    const md = `:::exercise
 :::task
 Task 1 content.
 :::
@@ -511,42 +539,42 @@ Task 1 content.
 Task 2 content.
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      
-      // No introduction child (no content before first task)
-      const firstChild = exercise.children[0] as Element;
-      expect(elName(firstChild)).toBe('task');
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
 
-    it('exercise without nested tasks wraps content in statement', () => {
-      const tree = parse(':::exercise\nExercise content.\n:::');
-      const exercise = tree.children[0] as Element;
-      const stmt = exercise.children[0] as Element;
-      expect(elName(stmt)).toBe('statement');
-    });
+    // No introduction child (no content before first task)
+    const firstChild = exercise.children[0] as Element;
+    expect(elName(firstChild)).toBe("task");
+  });
 
-    it('project directive supports nested tasks like exercise', () => {
-      const md = `:::project
+  it("exercise without nested tasks wraps content in statement", () => {
+    const tree = parse(":::exercise\nExercise content.\n:::");
+    const exercise = tree.children[0] as Element;
+    const stmt = exercise.children[0] as Element;
+    expect(elName(stmt)).toBe("statement");
+  });
+
+  it("project directive supports nested tasks like exercise", () => {
+    const md = `:::project
 Project intro.
 
 :::task
 Task content.
 :::
 :::`;
-      const tree = parse(md);
-      const project = tree.children[0] as Element;
-      expect(elName(project)).toBe('project');
-      
-      const intro = project.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      const task = project.children[1] as Element;
-      expect(elName(task)).toBe('task');
-    });
+    const tree = parse(md);
+    const project = tree.children[0] as Element;
+    expect(elName(project)).toBe("project");
 
-    it('drops interstitial non-task content and wraps trailing content in conclusion', () => {
-      const md = `:::exercise
+    const intro = project.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    const task = project.children[1] as Element;
+    expect(elName(task)).toBe("task");
+  });
+
+  it("drops interstitial non-task content and wraps trailing content in conclusion", () => {
+    const md = `:::exercise
 Intro text.
 
 :::task
@@ -561,20 +589,20 @@ Task 2.
 
 Concluding text.
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      const xml = toXml(tree);
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    const xml = toXml(tree);
 
-      expect(elName(exercise.children[0])).toBe('introduction');
-      expect(elName(exercise.children[1])).toBe('task');
-      expect(elName(exercise.children[2])).toBe('task');
-      expect(elName(exercise.children[3])).toBe('conclusion');
-      expect(xml).not.toContain('Dropped between tasks.');
-      expect(xml).toContain('Concluding text.');
-    });
+    expect(elName(exercise.children[0])).toBe("introduction");
+    expect(elName(exercise.children[1])).toBe("task");
+    expect(elName(exercise.children[2])).toBe("task");
+    expect(elName(exercise.children[3])).toBe("conclusion");
+    expect(xml).not.toContain("Dropped between tasks.");
+    expect(xml).toContain("Concluding text.");
+  });
 
-    it('records warning when dropping content between tasks', () => {
-      const md = `::::exercise
+  it("records warning when dropping content between tasks", () => {
+    const md = `::::exercise
 :::task
 Task 1.
 :::
@@ -585,56 +613,56 @@ Dropped between tasks.
 Task 2.
 :::
 ::::`;
-      const result = parseWithDiagnostics(md);
-      const warning = result.messages.find(
-        (message) => message.category === 'dropped-content-between-tasks'
-      );
+    const result = parseWithDiagnostics(md);
+    const warning = result.messages.find(
+      (message) => message.category === "dropped-content-between-tasks",
+    );
 
-      expect(warning).toBeDefined();
-    });
+    expect(warning).toBeDefined();
   });
+});
 
-  describe('colon normalization (flexible directive syntax)', () => {
-    it('single ::: markers for nested directives (normalizer equalizes outer)', () => {
-      const md = `:::exercise
+describe("colon normalization (flexible directive syntax)", () => {
+  it("single ::: markers for nested directives (normalizer equalizes outer)", () => {
+    const md = `:::exercise
 Intro
 
 :::task
 Task content
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      const intro = exercise.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      const task = exercise.children[1] as Element;
-      expect(elName(task)).toBe('task');
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('mixed colon counts (4 outer, 3 inner) still parse correctly', () => {
-      const md = `::::exercise
+    const intro = exercise.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    const task = exercise.children[1] as Element;
+    expect(elName(task)).toBe("task");
+  });
+
+  it("mixed colon counts (4 outer, 3 inner) still parse correctly", () => {
+    const md = `::::exercise
 Intro
 
 :::task
 Content
 :::
 ::::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      const intro = exercise.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      const task = exercise.children[1] as Element;
-      expect(elName(task)).toBe('task');
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('multiple siblings at same depth with uniform colons', () => {
-      const md = `:::exercise
+    const intro = exercise.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    const task = exercise.children[1] as Element;
+    expect(elName(task)).toBe("task");
+  });
+
+  it("multiple siblings at same depth with uniform colons", () => {
+    const md = `:::exercise
 Intro
 
 :::task
@@ -645,18 +673,18 @@ Task 1
 Task 2
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      
-      const intro = exercise.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      // Should have intro + 1 task (due to remark-directive limitation on sibling parsing)
-      expect(exercise.children.length).toBeGreaterThan(0);
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
 
-    it('deeply nested (3 levels) with flexible colons', () => {
-      const md = `:::exercise
+    const intro = exercise.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    // Should have intro + 1 task (due to remark-directive limitation on sibling parsing)
+    expect(exercise.children.length).toBeGreaterThan(0);
+  });
+
+  it("deeply nested (3 levels) with flexible colons", () => {
+    const md = `:::exercise
 Intro
 
 :::task
@@ -667,35 +695,35 @@ Proof content
 :::
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      const intro = exercise.children[0] as Element;
-      expect(elName(intro)).toBe('introduction');
-      
-      const task = exercise.children[1] as Element;
-      expect(elName(task)).toBe('task');
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('mismatched closing markers (no matching open) leave literal text', () => {
-      // If user writes ::: with no matching open, normalizer leaves it as-is
-      // remark-directive treats it as literal text
-      const md = `:::
+    const intro = exercise.children[0] as Element;
+    expect(elName(intro)).toBe("introduction");
+
+    const task = exercise.children[1] as Element;
+    expect(elName(task)).toBe("task");
+  });
+
+  it("mismatched closing markers (no matching open) leave literal text", () => {
+    // If user writes ::: with no matching open, normalizer leaves it as-is
+    // remark-directive treats it as literal text
+    const md = `:::
 Orphan closing marker
 :::`;
-      const tree = parse(md);
-      // Should parse as paragraph, not as directive (orphan marker treated as literal)
-      expect(tree.children.length).toBeGreaterThan(0);
-      const firstChild = tree.children[0] as Element;
-      // Orphan markers become text, not directives
-      expect(firstChild.name).not.toBe('exercise');
-    });
+    const tree = parse(md);
+    // Should parse as paragraph, not as directive (orphan marker treated as literal)
+    expect(tree.children.length).toBeGreaterThan(0);
+    const firstChild = tree.children[0] as Element;
+    // Orphan markers become text, not directives
+    expect(firstChild.name).not.toBe("exercise");
+  });
 
-    it('user reported case: mixed colon counts (3 outer, 4 inner, 3 inner)', () => {
-      // User reported: :::exercise with ::::task followed by :::task dropped second task
-      // After normalization should become: :::::exercise with ::::task and :::task
-      const md = `:::exercise[Pythagorean Theorem]{#thm-pythagoras}
+  it("user reported case: mixed colon counts (3 outer, 4 inner, 3 inner)", () => {
+    // User reported: :::exercise with ::::task followed by :::task dropped second task
+    // After normalization should become: :::::exercise with ::::task and :::task
+    const md = `:::exercise[Pythagorean Theorem]{#thm-pythagoras}
 For a...
 
 ::::task
@@ -706,104 +734,112 @@ Let $ABC$ be a right triangle. The result follows.
 Another proof.
 :::
 :::`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      // With title [Pythagorean Theorem], first child is 'title', not 'introduction'
-      let introIdx = 0;
-      if (elName(exercise.children[0]) === 'title') {
-        introIdx = 1;
-      }
-      
-      const intro = exercise.children[introIdx] as Element;
-      expect(elName(intro)).toBe('introduction');
-      expect(intro.children.length).toBeGreaterThan(0);
-      
-      // Should have: title + intro + at least one task (or intro + task if no title)
-      expect(exercise.children.length).toBeGreaterThanOrEqual(2);
-      
-      // Find a task element in the exercise children
-      const taskChild = exercise.children.find((child: any) => elName(child) === 'task');
-      expect(taskChild).toBeDefined();
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('does not rewrite ::: markers inside fenced code blocks', () => {
-      const md = `\`\`\`md
+    // With title [Pythagorean Theorem], first child is 'title', not 'introduction'
+    let introIdx = 0;
+    if (elName(exercise.children[0]) === "title") {
+      introIdx = 1;
+    }
+
+    const intro = exercise.children[introIdx] as Element;
+    expect(elName(intro)).toBe("introduction");
+    expect(intro.children.length).toBeGreaterThan(0);
+
+    // Should have: title + intro + at least one task (or intro + task if no title)
+    expect(exercise.children.length).toBeGreaterThanOrEqual(2);
+
+    // Find a task element in the exercise children
+    const taskChild = exercise.children.find(
+      (child: any) => elName(child) === "task",
+    );
+    expect(taskChild).toBeDefined();
+  });
+
+  it("does not rewrite ::: markers inside fenced code blocks", () => {
+    const md = `\`\`\`md
 :::exercise
 :::task
 :::
 :::
 \`\`\``;
-      const tree = parse(md);
-      const program = tree.children[0] as Element;
+    const tree = parse(md);
+    const program = tree.children[0] as Element;
 
-      expect(elName(program)).toBe('program');
-      expect(getPtxTextContent(program)).toBe(':::exercise\n:::task\n:::\n:::');
-    });
+    expect(elName(program)).toBe("program");
+    expect(getPtxTextContent(program)).toBe(":::exercise\n:::task\n:::\n:::");
+  });
 
-    it('does not keep malformed non-top stack matches open', () => {
-      const md = `::::exercise
+  it("does not keep malformed non-top stack matches open", () => {
+    const md = `::::exercise
 :::task
 ::::
 :::example
 :::
 ::::`;
-      const normalized = normalizeDirectiveColons(md);
-      const lines = normalized.split('\n');
+    const normalized = normalizeDirectiveColons(md);
+    const lines = normalized.split("\n");
 
-      expect(lines[2]).toBe('::::');
-      expect(lines[3]).toBe(':::example');
-      expect(lines[4]).toBe(':::');
-    });
-
-    it('accepts mixed-case directive names', () => {
-      const tree = parse(':::Theorem\nContent.\n:::');
-      const theorem = tree.children[0] as Element;
-      expect(elName(theorem)).toBe('theorem');
-    });
+    expect(lines[2]).toBe("::::");
+    expect(lines[3]).toBe(":::example");
+    expect(lines[4]).toBe(":::");
   });
 
-  describe('indentation-based directive syntax', () => {
-    it('basic single directive with indented content', () => {
-      const md = `Theorem[Pythagorean]{#thm}:
+  it("accepts mixed-case directive names", () => {
+    const tree = parse(":::Theorem\nContent.\n:::");
+    const theorem = tree.children[0] as Element;
+    expect(elName(theorem)).toBe("theorem");
+  });
+});
+
+describe("indentation-based directive syntax", () => {
+  it("basic single directive with indented content", () => {
+    const md = `Theorem[Pythagorean]{#thm}:
   The statement goes here.
   
   More content.
 
 Plain text.`;
-      const tree = parse(md);
-      const theorem = tree.children[0] as Element;
-      expect(elName(theorem)).toBe('theorem');
-      
-      // Should have title + statement
-      const statement = theorem.children.find((child: any) => elName(child) === 'statement');
-      expect(statement).toBeDefined();
-    });
+    const tree = parse(md);
+    const theorem = tree.children[0] as Element;
+    expect(elName(theorem)).toBe("theorem");
 
-    it('nested directives with indentation', () => {
-      const md = `Exercise[Basic]{#ex1}:
+    // Should have title + statement
+    const statement = theorem.children.find(
+      (child: any) => elName(child) === "statement",
+    );
+    expect(statement).toBeDefined();
+  });
+
+  it("nested directives with indentation", () => {
+    const md = `Exercise[Basic]{#ex1}:
   Solve this problem.
   
   Proof:
     This is the solution.
 
 More text.`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      // Should have statement (since no nested tasks)
-      const statement = exercise.children.find((child: any) => elName(child) === 'statement');
-      expect(statement).toBeDefined();
-      
-      // Should have a proof directive nested inside
-      const proof = exercise.children.find((child: any) => elName(child) === 'proof');
-      expect(proof).toBeDefined();
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('deeply nested (3 levels) with indentation', () => {
-      const md = `Exercise:
+    // Should have statement (since no nested tasks)
+    const statement = exercise.children.find(
+      (child: any) => elName(child) === "statement",
+    );
+    expect(statement).toBeDefined();
+
+    // Should have a proof directive nested inside
+    const proof = exercise.children.find(
+      (child: any) => elName(child) === "proof",
+    );
+    expect(proof).toBeDefined();
+  });
+
+  it("deeply nested (3 levels) with indentation", () => {
+    const md = `Exercise:
   An exercise.
   
   Task:
@@ -813,57 +849,67 @@ More text.`;
       The proof.
 
 Outside.`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      const intro = exercise.children.find((child: any) => elName(child) === 'introduction');
-      expect(intro).toBeDefined();
-      
-      const task = exercise.children.find((child: any) => elName(child) === 'task');
-      expect(task).toBeDefined();
-      
-      if (task) {
-        const proof = task.children.find((child: any) => elName(child) === 'proof');
-        expect(proof).toBeDefined();
-      }
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('case-insensitive directive keywords', () => {
-      const md = `theorem:
+    const intro = exercise.children.find(
+      (child: any) => elName(child) === "introduction",
+    );
+    expect(intro).toBeDefined();
+
+    const task = exercise.children.find(
+      (child: any) => elName(child) === "task",
+    );
+    expect(task).toBeDefined();
+
+    if (task) {
+      const proof = task.children.find(
+        (child: any) => elName(child) === "proof",
+      );
+      expect(proof).toBeDefined();
+    }
+  });
+
+  it("case-insensitive directive keywords", () => {
+    const md = `theorem:
   Statement here.
 
 PROOF:
   Proof here.`;
-      const tree = parse(md);
-      const theorem = tree.children[0] as Element;
-      expect(elName(theorem)).toBe('theorem');
-      
-      // The PROOF should be nested if it's indented, or a sibling if not
-      // In this case it's not indented, so it's a sibling
-      const proof = tree.children[1] as Element;
-      expect(elName(proof)).toBe('proof');
-    });
+    const tree = parse(md);
+    const theorem = tree.children[0] as Element;
+    expect(elName(theorem)).toBe("theorem");
 
-    it('mixed indentation and colon syntax in same document', () => {
-      const md = `Exercise[First]:
+    // The PROOF should be nested if it's indented, or a sibling if not
+    // In this case it's not indented, so it's a sibling
+    const proof = tree.children[1] as Element;
+    expect(elName(proof)).toBe("proof");
+  });
+
+  it("mixed indentation and colon syntax in same document", () => {
+    const md = `Exercise[First]:
   Using indentation.
 
 :::theorem
 Using colons.
 :::`;
-      const tree = parse(md);
-      
-      // Should have exercise and theorem as siblings
-      const exercise = tree.children.find((child: any) => elName(child) === 'exercise');
-      const theorem = tree.children.find((child: any) => elName(child) === 'theorem');
-      
-      expect(exercise).toBeDefined();
-      expect(theorem).toBeDefined();
-    });
+    const tree = parse(md);
 
-    it('code and math blocks not treated as directives', () => {
-      const md = `Example:
+    // Should have exercise and theorem as siblings
+    const exercise = tree.children.find(
+      (child: any) => elName(child) === "exercise",
+    );
+    const theorem = tree.children.find(
+      (child: any) => elName(child) === "theorem",
+    );
+
+    expect(exercise).toBeDefined();
+    expect(theorem).toBeDefined();
+  });
+
+  it("code and math blocks not treated as directives", () => {
+    const md = `Example:
   Consider this code block:
   
   \`\`\`
@@ -871,49 +917,57 @@ Using colons.
   \`\`\`
   
   And $Theorem: x = y$ is inline math.`;
-      const tree = parse(md);
-      const example = tree.children[0] as Element;
-      expect(elName(example)).toBe('example');
-      
-      // The example should successfully parse without treating code/math as directives
-      expect(example.children.length).toBeGreaterThan(0);
-    });
+    const tree = parse(md);
+    const example = tree.children[0] as Element;
+    expect(elName(example)).toBe("example");
 
-    it('preserves relative indentation of nested lists', () => {
-      const md = `Exercise:
+    // The example should successfully parse without treating code/math as directives
+    expect(example.children.length).toBeGreaterThan(0);
+  });
+
+  it("preserves relative indentation of nested lists", () => {
+    const md = `Exercise:
   Solve the following:
   
   - Item 1
     - Sub-item 1a
     - Sub-item 1b
   - Item 2`;
-      const tree = parse(md);
-      const exercise = tree.children[0] as Element;
-      expect(elName(exercise)).toBe('exercise');
-      
-      // Find the statement inside exercise (where content is wrapped)
-      const statement = exercise.children.find((child: any) => elName(child) === 'statement') as Element;
-      expect(statement).toBeDefined();
-      
-      // Find the p element inside statement (text is now wrapped in paragraph)
-      const p = statement?.children?.find((c: any) => elName(c) === 'p') as Element;
-      expect(p).toBeDefined();
-      
-      // Find the ul inside the paragraph (list is nested inside paragraph)
-      const ul = p?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      expect(ul).toBeDefined();
-      
-      // First li should have p element containing nested ul
-      const firstLi = ul?.children?.[0] as Element;
-      const firstLiP = firstLi?.children?.find((c: any) => elName(c) === 'p') as Element;
-      const nestedUl = firstLiP?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      
-      expect(nestedUl).toBeDefined();
-      expect(nestedUl?.children?.length).toBe(2); // Sub-item 1a and 1b
-    });
+    const tree = parse(md);
+    const exercise = tree.children[0] as Element;
+    expect(elName(exercise)).toBe("exercise");
 
-    it('deeply nested lists (3 levels)', () => {
-      const md = `Theorem:
+    // Find the statement inside exercise (where content is wrapped)
+    const statement = exercise.children.find(
+      (child: any) => elName(child) === "statement",
+    ) as Element;
+    expect(statement).toBeDefined();
+
+    // Find the p element inside statement (text is now wrapped in paragraph)
+    const p = statement?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    expect(p).toBeDefined();
+
+    // Find the ul inside the paragraph (list is nested inside paragraph)
+    const ul = p?.children?.find((c: any) => elName(c) === "ul") as Element;
+    expect(ul).toBeDefined();
+
+    // First li should have p element containing nested ul
+    const firstLi = ul?.children?.[0] as Element;
+    const firstLiP = firstLi?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    const nestedUl = firstLiP?.children?.find(
+      (c: any) => elName(c) === "ul",
+    ) as Element;
+
+    expect(nestedUl).toBeDefined();
+    expect(nestedUl?.children?.length).toBe(2); // Sub-item 1a and 1b
+  });
+
+  it("deeply nested lists (3 levels)", () => {
+    const md = `Theorem:
   Main statement.
   
   - Level 1
@@ -921,38 +975,50 @@ Using colons.
       - Level 3a
       - Level 3b
     - Level 2b`;
-      const tree = parse(md);
-      const theorem = tree.children[0] as Element;
-      expect(elName(theorem)).toBe('theorem');
-      
-      // Find statement inside theorem
-      const statement = theorem.children.find((child: any) => elName(child) === 'statement') as Element;
-      expect(statement).toBeDefined();
-      
-      // Find the p element inside statement (text is wrapped in paragraph)
-      const p = statement?.children?.find((c: any) => elName(c) === 'p') as Element;
-      expect(p).toBeDefined();
-      
-      // Find the ul inside the paragraph (list is nested inside paragraph)
-      const ul = p?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      expect(ul).toBeDefined();
-      
-      // Verify structure is preserved (not flattened) with 3 levels of nesting
-      const level1Li = ul?.children?.[0] as Element;
-      const level1P = level1Li?.children?.find((c: any) => elName(c) === 'p') as Element;
-      const level2Ul = level1P?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      
-      expect(level2Ul).toBeDefined();
-      const level2Li = level2Ul?.children?.[0] as Element;
-      const level2P = level2Li?.children?.find((c: any) => elName(c) === 'p') as Element;
-      const level3Ul = level2P?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      
-      expect(level3Ul).toBeDefined();
-      expect(level3Ul?.children?.length).toBe(2); // Level 3a and 3b
-    });
+    const tree = parse(md);
+    const theorem = tree.children[0] as Element;
+    expect(elName(theorem)).toBe("theorem");
 
-    it('nested list with surrounding text', () => {
-      const md = `Solution:
+    // Find statement inside theorem
+    const statement = theorem.children.find(
+      (child: any) => elName(child) === "statement",
+    ) as Element;
+    expect(statement).toBeDefined();
+
+    // Find the p element inside statement (text is wrapped in paragraph)
+    const p = statement?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    expect(p).toBeDefined();
+
+    // Find the ul inside the paragraph (list is nested inside paragraph)
+    const ul = p?.children?.find((c: any) => elName(c) === "ul") as Element;
+    expect(ul).toBeDefined();
+
+    // Verify structure is preserved (not flattened) with 3 levels of nesting
+    const level1Li = ul?.children?.[0] as Element;
+    const level1P = level1Li?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    const level2Ul = level1P?.children?.find(
+      (c: any) => elName(c) === "ul",
+    ) as Element;
+
+    expect(level2Ul).toBeDefined();
+    const level2Li = level2Ul?.children?.[0] as Element;
+    const level2P = level2Li?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    const level3Ul = level2P?.children?.find(
+      (c: any) => elName(c) === "ul",
+    ) as Element;
+
+    expect(level3Ul).toBeDefined();
+    expect(level3Ul?.children?.length).toBe(2); // Level 3a and 3b
+  });
+
+  it("nested list with surrounding text", () => {
+    const md = `Solution:
   First part of solution.
   
   Key steps:
@@ -961,60 +1027,70 @@ Using colons.
   - Step 2
   
   Conclusion here.`;
-      const tree = parse(md);
-      const solution = tree.children[0] as Element;
-      expect(elName(solution)).toBe('solution');
-      
-      // Solution doesn't wrap content in a statement, so look directly in solution
-      // Find the p element that contains "Key steps:" (second p element)
-      const pWithList = solution.children?.find((c: any) => {
-        if (elName(c) !== 'p') return false;
-        return c.children?.some((child: any) => child.value === 'Key steps:');
-      }) as Element;
-      expect(pWithList).toBeDefined();
-      
-      // Find the ul inside that paragraph
-      const ul = pWithList?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      expect(ul).toBeDefined();
-      
-      const listItems = ul?.children;
-      expect(listItems?.length).toBe(2); // Step 1 and Step 2
-      
-      const step1Li = listItems?.[0] as Element;
-      const step1P = step1Li?.children?.find((c: any) => elName(c) === 'p') as Element;
-      const step1NestedUl = step1P?.children?.find((c: any) => elName(c) === 'ul') as Element;
-      expect(step1NestedUl).toBeDefined();
-    });
+    const tree = parse(md);
+    const solution = tree.children[0] as Element;
+    expect(elName(solution)).toBe("solution");
 
-    it('4-space indented body is not parsed as code block', () => {
-      // Regression: body with 4-space indent was previously parsed as a <pre> code block
-      const md = `Theorem:
+    // Solution doesn't wrap content in a statement, so look directly in solution
+    // Find the p element that contains "Key steps:" (second p element)
+    const pWithList = solution.children?.find((c: any) => {
+      if (elName(c) !== "p") return false;
+      return c.children?.some((child: any) => child.value === "Key steps:");
+    }) as Element;
+    expect(pWithList).toBeDefined();
+
+    // Find the ul inside that paragraph
+    const ul = pWithList?.children?.find(
+      (c: any) => elName(c) === "ul",
+    ) as Element;
+    expect(ul).toBeDefined();
+
+    const listItems = ul?.children;
+    expect(listItems?.length).toBe(2); // Step 1 and Step 2
+
+    const step1Li = listItems?.[0] as Element;
+    const step1P = step1Li?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    const step1NestedUl = step1P?.children?.find(
+      (c: any) => elName(c) === "ul",
+    ) as Element;
+    expect(step1NestedUl).toBeDefined();
+  });
+
+  it("4-space indented body is not parsed as code block", () => {
+    // Regression: body with 4-space indent was previously parsed as a <pre> code block
+    const md = `Theorem:
     This is the theorem statement.
 
 Plain text after.`;
-      const tree = parse(md);
-      const theorem = tree.children[0] as Element;
-      expect(elName(theorem)).toBe('theorem');
-      const statement = theorem.children.find((c: any) => elName(c) === 'statement') as Element;
-      expect(statement).toBeDefined();
-      // The content must be a paragraph, not a code block
-      const p = statement?.children?.find((c: any) => elName(c) === 'p') as Element;
-      expect(p).toBeDefined();
-      expect(tree.children.some((c: any) => elName(c) === 'pre')).toBe(false);
-    });
+    const tree = parse(md);
+    const theorem = tree.children[0] as Element;
+    expect(elName(theorem)).toBe("theorem");
+    const statement = theorem.children.find(
+      (c: any) => elName(c) === "statement",
+    ) as Element;
+    expect(statement).toBeDefined();
+    // The content must be a paragraph, not a code block
+    const p = statement?.children?.find(
+      (c: any) => elName(c) === "p",
+    ) as Element;
+    expect(p).toBeDefined();
+    expect(tree.children.some((c: any) => elName(c) === "pre")).toBe(false);
+  });
 
-    it('4-space indented list inside directive is parsed as a list', () => {
-      const md = `Example:
+  it("4-space indented list inside directive is parsed as a list", () => {
+    const md = `Example:
     Some intro text.
 
     - First item
     - Second item`;
-      const tree = parse(md);
-      const example = tree.children[0] as Element;
-      expect(elName(example)).toBe('example');
-      // The list should be preserved, not turned into a code block
-      const allNames = nodeNameCounts(tree);
-      expect(allNames['ul']).toBeGreaterThanOrEqual(1);
-      expect(allNames['pre']).toBeUndefined();
-    });
+    const tree = parse(md);
+    const example = tree.children[0] as Element;
+    expect(elName(example)).toBe("example");
+    // The list should be preserved, not turned into a code block
+    const allNames = nodeNameCounts(tree);
+    expect(allNames["ul"]).toBeGreaterThanOrEqual(1);
+    expect(allNames["pre"]).toBeUndefined();
   });
+});

--- a/packages/vscode-extension/assets/schema/pretext-dev.rng
+++ b/packages/vscode-extension/assets/schema/pretext-dev.rng
@@ -282,7 +282,9 @@
   </define>
   <define name="Configuration" combine="choice">
     <element name="blurb">
-      <attribute name="shelf"/>
+      <optional>
+        <attribute name="shelf"/>
+      </optional>
       <text/>
     </element>
   </define>


### PR DESCRIPTION
This handles incorrect markdown-style pretext better, instead of just silently dropping it.