### PR TITLE
Markdown frontmatter and inclusions

### DIFF
--- a/.changeset/green-experts-argue.md
+++ b/.changeset/green-experts-argue.md
@@ -1,0 +1,7 @@
+---
+"@pretextbook/ptxast-util-to-mdast": patch
+"@pretextbook/remark-pretext": patch
+"@pretextbook/ptxast": patch
+---
+
+Fix root division frontmatter; convert leaf node directives to plus:type includes

--- a/packages/ptxast-util-to-mdast/src/lib/ptxast-to-mdast.ts
+++ b/packages/ptxast-util-to-mdast/src/lib/ptxast-to-mdast.ts
@@ -61,7 +61,7 @@ export const TITLELESS_DIVISION_TYPES = new Set<string>(TITLELESS_DIVISION_TYPE_
  * hierarchy.
  */
 export const TRANSPARENT_TYPES = new Set([
-  'pretext', 'book', 'article', 'frontmatter', 'backmatter',
+  'pretext', 'book', 'article', 'slideshow', 'frontmatter', 'backmatter',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/ptxast/src/lib/division-hierarchy.ts
+++ b/packages/ptxast/src/lib/division-hierarchy.ts
@@ -44,7 +44,8 @@ export type ExtraDivisionType =
   | 'solutions'
   | 'reading-questions'
   | 'introduction'
-  | 'conclusion';
+  | 'conclusion'
+  | 'slide';
 
 export const EXTRA_DIVISION_TYPES: readonly ExtraDivisionType[] = [
   'worksheet',
@@ -57,6 +58,7 @@ export const EXTRA_DIVISION_TYPES: readonly ExtraDivisionType[] = [
   'reading-questions',
   'introduction',
   'conclusion',
+  'slide',
 ];
 
 export function isExtraDivisionType(value: string): value is ExtraDivisionType {
@@ -113,4 +115,68 @@ export function divisionTypeAtRelativeDepth(
   const startIndex = DIVISION_HIERARCHY.indexOf(topLevel);
   const index = startIndex + (depth - 1);
   return DIVISION_HIERARCHY[Math.min(index, DIVISION_HIERARCHY.length - 1)];
+}
+
+/**
+ * PreTeXt document roots that can wrap an entire document. Unlike the
+ * heading-producible divisions above, these are never chosen via heading
+ * depth: they wrap the whole document, and a depth-1 heading (`#`) becomes
+ * their outermost *child* division (see `rootChildDivision`).
+ */
+export type RootDivisionType = 'article' | 'book' | 'slideshow';
+
+export const ROOT_DIVISION_TYPES: readonly RootDivisionType[] = [
+  'article',
+  'book',
+  'slideshow',
+];
+
+export function isRootDivisionType(value: string): value is RootDivisionType {
+  return (ROOT_DIVISION_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * The division a depth-1 heading (`#`) maps to inside a given document root:
+ * `book` numbers chapters, `article` numbers sections, and `slideshow`
+ * contains sections that can contain slides. Deeper headings nest down from there via
+ * `divisionTypeAtRelativeDepth` (chapters nest sections, sections nest
+ * subsections, and slides — like other non-hierarchy divisions — clamp to
+ * `paragraphs`).
+ */
+export function rootChildDivision(
+  root: RootDivisionType,
+): TopLevelDivisionType {
+  return divisionTypeAtRootDepth(root, 1);
+}
+
+/**
+ * A slideshow has its own division hierarchy: depth-1 headings become
+ * `section`s, depth-2 headings become the `slide`s inside them, and anything
+ * deeper collapses to `paragraphs`. (It intentionally does not reuse the
+ * `section` → `subsection` chain of `DIVISION_HIERARCHY`.)
+ */
+const SLIDESHOW_HIERARCHY: readonly (DivisionType | ExtraDivisionType)[] = [
+  'section',
+  'slide',
+  'paragraphs',
+];
+
+/**
+ * Resolve the division type at heading `depth` (1-based) inside a given
+ * document root. `book` starts at `chapter`, `article` at `section` (both
+ * then following `DIVISION_HIERARCHY`), and `slideshow` follows its own
+ * `section` → `slide` → `paragraphs` chain.
+ */
+export function divisionTypeAtRootDepth(
+  root: RootDivisionType,
+  depth: number,
+): DivisionType | ExtraDivisionType {
+  if (root === 'slideshow') {
+    const index = Math.max(0, depth - 1);
+    return SLIDESHOW_HIERARCHY[
+      Math.min(index, SLIDESHOW_HIERARCHY.length - 1)
+    ];
+  }
+  const child = root === 'book' ? 'chapter' : 'section';
+  return divisionTypeAtRelativeDepth(child, depth);
 }

--- a/packages/remark-pretext/src/lib/context.ts
+++ b/packages/remark-pretext/src/lib/context.ts
@@ -6,7 +6,7 @@
  */
 
 import type { BlockContent, DefinitionContent, PhrasingContent } from 'mdast';
-import type { TopLevelDivisionType } from '@pretextbook/ptxast';
+import type { RootDivisionType, TopLevelDivisionType } from '@pretextbook/ptxast';
 
 export interface VisitContext {
   /** Parent node, if any. */
@@ -21,6 +21,10 @@ export interface VisitContext {
   source?: string;
   /** The division type that a depth-1 heading (`#`) maps to. */
   topLevelDivision: TopLevelDivisionType;
+  /** When set, the whole document is wrapped in this root element
+   * (`book`/`article`/`slideshow`) and `topLevelDivision` is the root's
+   * outermost child division. */
+  documentRoot?: RootDivisionType;
   /** Attributes (e.g. from frontmatter `xmlid`/`label`/`component`) to apply
    * to the first root-level division built from the document. */
   topLevelAttributes?: Record<string, string>;

--- a/packages/remark-pretext/src/lib/frontmatter.ts
+++ b/packages/remark-pretext/src/lib/frontmatter.ts
@@ -1,17 +1,30 @@
 /**
  * Minimal string-level parser for a leading YAML-style frontmatter block
  * (`---\n...\n---`) used to declare document metadata before any other
- * markdown processing happens. Only `division:`, `xmlid:`, `label:`, and
- * `component:` fields are recognized today; this is intentionally not a
- * general YAML parser.
+ * markdown processing happens. Only `division:`, `xmlid:` (a.k.a. `xml:id:`),
+ * `label:`, and `component:` fields are recognized today; this is
+ * intentionally not a general YAML parser.
+ *
+ * `division:` accepts either a heading-producible division (`section`,
+ * `worksheet`, ...) or a document root (`book`, `article`, `slideshow`). A
+ * root wraps the whole document; its depth-1 headings become the root's
+ * outermost child division (see `rootChildDivision`).
  */
 
-import { isTopLevelDivisionType } from "@pretextbook/ptxast";
-import type { TopLevelDivisionType } from "@pretextbook/ptxast";
+import {
+  isRootDivisionType,
+  isTopLevelDivisionType,
+  rootChildDivision,
+} from "@pretextbook/ptxast";
+import type { RootDivisionType, TopLevelDivisionType } from "@pretextbook/ptxast";
 
 export interface FrontmatterResult {
-  /** The declared top-level division type, if present and valid. */
+  /** The division a depth-1 heading (`#`) maps to, if present and valid. When
+   * `documentRoot` is set this is the root's outermost child division. */
   division?: TopLevelDivisionType;
+  /** The document root (`book`/`article`/`slideshow`) to wrap the whole
+   * document in, when `division:` names one. */
+  documentRoot?: RootDivisionType;
   /** Attributes (`xml:id`, `label`, `component`) for the top-level division. */
   attributes?: Record<string, string>;
   /** The markdown source with the frontmatter block removed. */
@@ -20,7 +33,9 @@ export interface FrontmatterResult {
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 const DIVISION_FIELD_RE = /^division:\s*(\S+)\s*$/m;
+// Accept both `xmlid:` and the `xml:id:` spelling (the PreTeXt attribute name).
 const XMLID_FIELD_RE = /^xmlid:\s*(\S+)\s*$/m;
+const XML_ID_FIELD_RE = /^xml:id:\s*(\S+)\s*$/m;
 const LABEL_FIELD_RE = /^label:\s*(\S+)\s*$/m;
 const COMPONENT_FIELD_RE = /^component:\s*(\S+)\s*$/m;
 
@@ -34,13 +49,18 @@ export function extractFrontmatter(markdown: string): FrontmatterResult {
   const body = markdown.slice(match[0].length);
 
   const divisionValue = block.match(DIVISION_FIELD_RE)?.[1];
-  const division =
-    divisionValue && isTopLevelDivisionType(divisionValue)
-      ? divisionValue
-      : undefined;
+  let division: TopLevelDivisionType | undefined;
+  let documentRoot: RootDivisionType | undefined;
+  if (divisionValue && isRootDivisionType(divisionValue)) {
+    documentRoot = divisionValue;
+    division = rootChildDivision(divisionValue);
+  } else if (divisionValue && isTopLevelDivisionType(divisionValue)) {
+    division = divisionValue;
+  }
 
   const attributes: Record<string, string> = {};
-  const xmlid = block.match(XMLID_FIELD_RE)?.[1];
+  const xmlid =
+    block.match(XMLID_FIELD_RE)?.[1] ?? block.match(XML_ID_FIELD_RE)?.[1];
   const label = block.match(LABEL_FIELD_RE)?.[1];
   const component = block.match(COMPONENT_FIELD_RE)?.[1];
   if (xmlid) attributes["xml:id"] = xmlid;
@@ -49,6 +69,7 @@ export function extractFrontmatter(markdown: string): FrontmatterResult {
 
   return {
     division,
+    documentRoot,
     attributes: Object.keys(attributes).length > 0 ? attributes : undefined,
     body,
   };

--- a/packages/remark-pretext/src/lib/markdown-to-pretext.ts
+++ b/packages/remark-pretext/src/lib/markdown-to-pretext.ts
@@ -36,5 +36,10 @@ export function markdownToPretext(
 
   const mdast = processor.parse(markdown);
   const ptxast = processor.runSync(mdast, { value: markdown }) as PtxRoot;
-  return toXml(ptxast.children);
+  // Self-close empty elements (`<plus:section ref="x"/>`, `<image .../>`) rather
+  // than emitting the expanded `<foo></foo>` form — the idiomatic PreTeXt shape.
+  return toXml(ptxast.children, {
+    closeEmptyElements: true,
+    tightClose: true,
+  });
 }

--- a/packages/remark-pretext/src/lib/mdast-to-ptxast.ts
+++ b/packages/remark-pretext/src/lib/mdast-to-ptxast.ts
@@ -36,16 +36,18 @@ import type {
   Blockquote as MdastBlockquote,
   Code,
 } from "mdast";
-import type { ContainerDirective } from "mdast-util-directive";
+import type { ContainerDirective, LeafDirective } from "mdast-util-directive";
 import type { Math as CustomMath } from "./math-parser.js";
+import { directiveToPlusInclude } from "./plus-include.js";
 import type { Root } from "xast";
 import type { Element } from "xast";
 import { getDirectiveSpec, DIRECTIVE_MAP } from "./directive-map.js";
 import { buildDirectiveWithSpec } from "./directive-factory.js";
 import type { VisitContext, ConversionMessage } from "./context.js";
-import type { TopLevelDivisionType } from "@pretextbook/ptxast";
+import type { RootDivisionType, TopLevelDivisionType } from "@pretextbook/ptxast";
 import {
   divisionTypeAtRelativeDepth,
+  divisionTypeAtRootDepth,
   isTitlelessDivisionType,
 } from "@pretextbook/ptxast";
 
@@ -157,6 +159,10 @@ export interface ConversionResult {
 export interface MdastToPtxastOptions {
   /** The division type that a depth-1 heading (`#`) maps to. Defaults to `'chapter'`. */
   topLevelDivision?: TopLevelDivisionType;
+  /** When set, wrap the whole document in this root element
+   * (`book`/`article`/`slideshow`); `topLevelDivision` is then the division a
+   * depth-1 heading maps to inside the root. */
+  documentRoot?: RootDivisionType;
   /** Attributes (`xml:id`, `label`, `component`) applied to the first
    * root-level division built from the document, e.g. from frontmatter. */
   topLevelAttributes?: Record<string, string>;
@@ -188,12 +194,28 @@ export function mdastToPtxastWithDiagnostics(
     messages,
     source,
     topLevelDivision: options?.topLevelDivision ?? "chapter",
+    documentRoot: options?.documentRoot,
     topLevelAttributes: options?.topLevelAttributes,
     topLevelAttributesApplied: options?.topLevelAttributes
       ? { done: false }
       : undefined,
   };
   const nodes = tree.children as Array<BlockContent | DefinitionContent>;
+
+  // A declared document root (`book`/`article`/`slideshow`) wraps the entire
+  // document. Its depth-1 headings have already been resolved to the root's
+  // outermost child division (`ctx.topLevelDivision`), so the body converts
+  // just like a normal document; we only wrap the result and hoist the
+  // frontmatter attributes onto the root element itself.
+  if (ctx.documentRoot) {
+    const attrs = takeTopLevelAttributes(ctx);
+    const bodyChildren = nestSections(nodes, ctx);
+    const wrapper = el(ctx.documentRoot, bodyChildren, attrs);
+    return {
+      tree: { type: "root", children: [wrapper] as Root["children"] },
+      messages,
+    };
+  }
 
   // `introduction`/`conclusion` have no `<title>` in the PreTeXt schema, so
   // they can't be produced from a heading like other divisions. Instead, the
@@ -349,10 +371,13 @@ function buildDivision(
   body: Array<BlockContent | DefinitionContent>,
   ctx: VisitContext,
 ): Element {
-  const divType = divisionTypeAtRelativeDepth(
-    ctx.topLevelDivision,
-    heading.depth,
-  );
+  // Inside a document root, headings follow that root's hierarchy
+  // (`slideshow` in particular nests `section` → `slide`, not
+  // `section` → `subsection`); otherwise use the relative hierarchy anchored
+  // at `topLevelDivision`.
+  const divType = ctx.documentRoot
+    ? divisionTypeAtRootDepth(ctx.documentRoot, heading.depth)
+    : divisionTypeAtRelativeDepth(ctx.topLevelDivision, heading.depth);
   const titleEl = el("title", convertInlineNodes(heading.children, ctx));
   const attrs = getDivisionAttrs(heading, ctx);
   // Inside divisions, orphaned lists need wrapping (wrapOrphanedLists=true)
@@ -415,6 +440,7 @@ const blockHandlers: Record<
   code: (node, ctx) => convertCode(node as Code, ctx),
   containerDirective: (node, ctx) =>
     convertContainerDirective(node as ContainerDirective, ctx),
+  leafDirective: (node, ctx) => convertLeafDirective(node as LeafDirective, ctx),
 };
 
 function convertBlock(
@@ -508,6 +534,39 @@ function convertMathNode(node: CustomMath, ctx: VisitContext): Element | null {
     return valueEl("m", node.value);
   }
   return convertDisplayMath(node, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Leaf directive converters
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a leaf directive (`::KIND{ref="id" key=value}`) into a PreTeXt Plus
+ * include element (`<plus:KIND ref="id" key=value/>`). Leaf directives are the
+ * include syntax for this markdown dialect — a reference to a modular section
+ * or asset, expanded by a later assembly step rather than transcluded here.
+ *
+ * Falls back to the unknown-block placeholder when the directive has no usable
+ * name (so nothing is silently dropped).
+ */
+function convertLeafDirective(
+  node: LeafDirective,
+  ctx: VisitContext,
+): Element | null {
+  const include = directiveToPlusInclude(node);
+  if (include) return include;
+  if (ctx.messages) {
+    ctx.messages.push({
+      type: "warning",
+      reason: `Unnamed leaf directive`,
+      category: "unknown-directive",
+    });
+  }
+  return todoBlock(
+    "unknown-directive",
+    `unnamed leaf directive`,
+    nodeSource(node, ctx),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/remark-pretext/src/lib/plus-include.ts
+++ b/packages/remark-pretext/src/lib/plus-include.ts
@@ -1,0 +1,76 @@
+/**
+ * PreTeXt Plus include conversion.
+ *
+ * PreTeXt Plus modularizes a document with `<plus:KIND ref="id" .../>`
+ * placeholders — a section, chapter, image, or other asset pulled in from
+ * elsewhere by reference (not transcluded here; a later assembly step expands
+ * them). In this markdown dialect those includes are authored as a
+ * remark-directive leaf directive:
+ *
+ *   ::section{ref="ch-intro"}
+ *   ::image{ref="fig-1" width="50%"}
+ *
+ * which convert to:
+ *
+ *   <plus:section ref="ch-intro"/>
+ *   <plus:image ref="fig-1" width="50%"/>
+ *
+ * Everything funnels through {@link plusIncludeElement}, the single builder for
+ * a `plus:` element. Recognizing a *source pattern* (the leaf directive here,
+ * or an inline text directive / image shorthand / ... later) is kept separate
+ * from building the element, so a new authoring pattern only needs to map
+ * itself to a `(kind, attributes)` pair and call the builder.
+ */
+
+import type { Element } from "xast";
+import type {
+  ContainerDirective,
+  LeafDirective,
+  TextDirective,
+} from "mdast-util-directive";
+
+/** Any of the three remark-directive node shapes (`:x`, `::x`, `:::x`). */
+type DirectiveNode = TextDirective | LeafDirective | ContainerDirective;
+
+/**
+ * Build a `<plus:KIND .../>` include element from a kind name and attributes.
+ *
+ * This is the one choke point every include syntax funnels through: the tag is
+ * always `plus:<kind>`, the element is always empty (a reference, never
+ * transcluded), and `null`/`undefined` attribute values are dropped so a
+ * value-less directive attribute doesn't emit `key="null"`.
+ */
+export function plusIncludeElement(
+  kind: string,
+  attributes: Record<string, string | null | undefined> = {},
+): Element {
+  const attrs: Record<string, string> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value == null) continue;
+    attrs[key] = value;
+  }
+  return {
+    type: "element",
+    name: `plus:${kind}`,
+    attributes: attrs,
+    children: [],
+  };
+}
+
+/**
+ * Interpret a remark-directive node as a PreTeXt Plus include: the directive
+ * name becomes the `plus:` kind and its attributes pass through verbatim
+ * (`::section{ref="x"}` → `<plus:section ref="x"/>`).
+ *
+ * Attributes are intentionally *not* remapped the way block directives remap
+ * `id`→`xml:id`: an include points at another element by `ref`, so its
+ * attributes are kept exactly as written.
+ *
+ * Returns `null` when the node carries no usable name, so callers can fall back
+ * to their normal handling rather than emitting `<plus:/>`.
+ */
+export function directiveToPlusInclude(node: DirectiveNode): Element | null {
+  const kind = node.name?.trim();
+  if (!kind) return null;
+  return plusIncludeElement(kind, node.attributes ?? {});
+}

--- a/packages/remark-pretext/src/lib/remark-pretext.spec.ts
+++ b/packages/remark-pretext/src/lib/remark-pretext.spec.ts
@@ -491,6 +491,121 @@ describe("relative top-level division", () => {
     const introduction = tree.children[0] as Element;
     expect(introduction.attributes["xml:id"]).toBe("intro-1");
   });
+
+  it("frontmatter accepts `xml:id` as a synonym for `xmlid`", () => {
+    const tree = parse(
+      "---\ndivision: section\nxml:id: my-id\n---\n\n# Title",
+    );
+    const section = tree.children[0] as Element;
+    expect(section.attributes["xml:id"]).toBe("my-id");
+  });
+
+  it("frontmatter `xmlid` still works alongside `label`", () => {
+    const tree = parse(
+      "---\ndivision: section\nxmlid: sec-1\nlabel: sec-label\n---\n\n# Title",
+    );
+    const section = tree.children[0] as Element;
+    expect(section.attributes["xml:id"]).toBe("sec-1");
+    expect(section.attributes["label"]).toBe("sec-label");
+  });
+});
+
+describe("document roots (book / article / slideshow)", () => {
+  it("division: book wraps the document in <book> and maps # to chapter", () => {
+    const tree = parse(
+      "---\ndivision: book\n---\n\n# Chapter One\n\n## A Section\n\nText.",
+    );
+    expect(tree.children).toHaveLength(1);
+    const book = tree.children[0] as Element;
+    expect(elName(book)).toBe("book");
+    const chapter = book.children.find(
+      (c) => elName(c) === "chapter",
+    ) as Element;
+    expect(chapter).toBeDefined();
+    expect(chapter.children.some((c) => elName(c) === "section")).toBe(true);
+  });
+
+  it("division: article wraps the document in <article> and maps # to section", () => {
+    const tree = parse(
+      "---\ndivision: article\n---\n\n# A Section\n\n## A Subsection\n\nText.",
+    );
+    const article = tree.children[0] as Element;
+    expect(elName(article)).toBe("article");
+    const section = article.children.find(
+      (c) => elName(c) === "section",
+    ) as Element;
+    expect(section).toBeDefined();
+    expect(section.children.some((c) => elName(c) === "subsection")).toBe(true);
+  });
+
+  it("division: slideshow wraps the document in <slideshow> and maps # to section", () => {
+    const tree = parse(
+      "---\ndivision: slideshow\n---\n\n# Section One\n\nBody.\n\n# Section Two\n\nMore.",
+    );
+    const slideshow = tree.children[0] as Element;
+    expect(elName(slideshow)).toBe("slideshow");
+    const sections = slideshow.children.filter((c) => elName(c) === "section");
+    expect(sections).toHaveLength(2);
+    const firstSection = sections[0] as Element;
+    const title = firstSection.children[0] as Element;
+    expect(elName(title)).toBe("title");
+    expect(textValue(title.children[0])).toBe("Section One");
+  });
+
+  it("division: slideshow nests slides (##) inside sections (#)", () => {
+    const tree = parse(
+      "---\ndivision: slideshow\n---\n\n# Section One\n\n## Slide A\n\nText.\n\n## Slide B\n\nMore.",
+    );
+    const section = (tree.children[0] as Element).children.find(
+      (c) => elName(c) === "section",
+    ) as Element;
+    const slides = section.children.filter((c) => elName(c) === "slide");
+    expect(slides).toHaveLength(2);
+    const firstSlide = slides[0] as Element;
+    expect(elName(firstSlide.children[0])).toBe("title");
+    expect(textValue((firstSlide.children[0] as Element).children[0])).toBe(
+      "Slide A",
+    );
+  });
+
+  it("headings deeper than a slide (###) become paragraphs", () => {
+    const tree = parse(
+      "---\ndivision: slideshow\n---\n\n# Section\n\n## Slide\n\n### Deeper\n\nText.",
+    );
+    const section = (tree.children[0] as Element).children.find(
+      (c) => elName(c) === "section",
+    ) as Element;
+    const slide = section.children.find(
+      (c) => elName(c) === "slide",
+    ) as Element;
+    expect(slide.children.some((c) => elName(c) === "paragraphs")).toBe(true);
+  });
+
+  it("frontmatter attributes are applied to the root element, not its first child", () => {
+    const tree = parse(
+      "---\ndivision: book\nxmlid: my-book\n---\n\n# Chapter One\n\nText.",
+    );
+    const book = tree.children[0] as Element;
+    expect(book.attributes["xml:id"]).toBe("my-book");
+    const chapter = book.children.find(
+      (c) => elName(c) === "chapter",
+    ) as Element;
+    expect(chapter.attributes?.["xml:id"]).toBeUndefined();
+  });
+
+  it("documentRoot option wraps the document even without frontmatter", () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .use(remarkPretext, { documentRoot: "book" });
+    const md = "# Chapter One\n\nText.";
+    const tree = processor.runSync(processor.parse(md), {
+      value: md,
+    }) as unknown as Root;
+    const book = tree.children[0] as Element;
+    expect(elName(book)).toBe("book");
+    expect(book.children.some((c) => elName(c) === "chapter")).toBe(true);
+  });
 });
 
 describe("container directives", () => {
@@ -795,6 +910,45 @@ Task 2.
     );
 
     expect(warning).toBeDefined();
+  });
+});
+
+describe("plus include leaf directives", () => {
+  it("::section{ref} → empty plus:section element with ref", () => {
+    const tree = parse('::section{ref="ch-intro"}');
+    const include = tree.children[0] as Element;
+    expect(elName(include)).toBe("plus:section");
+    expect(include.attributes?.["ref"]).toBe("ch-intro");
+    expect(include.children).toHaveLength(0);
+  });
+
+  it("passes extra attributes through verbatim (no id→xml:id remap)", () => {
+    const tree = parse('::image{ref="fig-1" width="50%"}');
+    const include = tree.children[0] as Element;
+    expect(elName(include)).toBe("plus:image");
+    expect(include.attributes).toMatchObject({ ref: "fig-1", width: "50%" });
+  });
+
+  it("any kind becomes plus:KIND (converter is not gated on a name list)", () => {
+    const tree = parse('::doenet{ref="activity-3"}');
+    expect(elName(tree.children[0])).toBe("plus:doenet");
+  });
+
+  it("serializes to a self-referencing plus element", () => {
+    const tree = parse('::section{ref="ch-intro"}');
+    const xml = toXml(tree.children[0] as Element);
+    expect(xml).toContain("plus:section");
+    expect(xml).toContain('ref="ch-intro"');
+  });
+
+  it("include survives inside a section body", () => {
+    const tree = parse("## A\n\n::section{ref=\"sub-a\"}");
+    const section = tree.children[0] as Element;
+    const include = section.children.find(
+      (c) => elName(c) === "plus:section",
+    ) as Element;
+    expect(include).toBeDefined();
+    expect(include.attributes?.["ref"]).toBe("sub-a");
   });
 });
 

--- a/packages/remark-pretext/src/lib/remark-pretext.ts
+++ b/packages/remark-pretext/src/lib/remark-pretext.ts
@@ -25,7 +25,7 @@
 import type { Plugin } from 'unified';
 import type { Root as MdastRoot } from 'mdast';
 import type { Root } from 'xast';
-import type { TopLevelDivisionType } from '@pretextbook/ptxast';
+import type { RootDivisionType, TopLevelDivisionType } from '@pretextbook/ptxast';
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkDirective from 'remark-directive';
@@ -34,6 +34,7 @@ import { applyMathDelimiters, applyMathTokens, tokenizeMathInMarkdown } from './
 import { normalizeDirectiveColons } from './directive-normalizer.js';
 import { normalizeIndentationDirectives } from './indentation-normalizer.js';
 import { extractFrontmatter } from './frontmatter.js';
+import { rootChildDivision } from '@pretextbook/ptxast';
 
 /** Options for the remark-pretext plugin. */
 export interface RemarkPretextOptions {
@@ -43,6 +44,13 @@ export interface RemarkPretextOptions {
    * `'chapter'` (matching historical behavior) when neither is set.
    */
   topLevelDivision?: TopLevelDivisionType;
+  /**
+   * Wraps the whole document in this root element (`book`/`article`/
+   * `slideshow`). Overrides any document root declared via the frontmatter
+   * `division:` field. When set, `topLevelDivision` is the division a depth-1
+   * heading maps to *inside* the root.
+   */
+  documentRoot?: RootDivisionType;
   /**
    * Attributes (`xml:id`, `label`, `component`) applied to the first
    * root-level division. Overrides any `xmlid:`/`label:`/`component:`
@@ -59,8 +67,11 @@ const remarkPretext: Plugin<[RemarkPretextOptions?], MdastRoot, Root> = function
     // from source text (no heuristic inference from parsed text nodes).
     if (typeof file?.value === 'string') {
       const frontmatter = extractFrontmatter(file.value);
+      const documentRoot = options?.documentRoot ?? frontmatter.documentRoot;
       const topLevelDivision =
-        options?.topLevelDivision ?? frontmatter.division ?? 'chapter';
+        options?.topLevelDivision ??
+        frontmatter.division ??
+        (documentRoot ? rootChildDivision(documentRoot) : 'chapter');
       const topLevelAttributes =
         options?.topLevelAttributes ?? frontmatter.attributes;
 
@@ -81,6 +92,7 @@ const remarkPretext: Plugin<[RemarkPretextOptions?], MdastRoot, Root> = function
       // pass tokenized source for delimiter detection
       return mdastToPtxast(reparsed, tokenized.markdown, {
         topLevelDivision,
+        documentRoot,
         topLevelAttributes,
       });
     }
@@ -88,7 +100,12 @@ const remarkPretext: Plugin<[RemarkPretextOptions?], MdastRoot, Root> = function
     // Fallback for parse+runSync(tree) usage where raw source text is unavailable.
     applyMathDelimiters(tree);
     return mdastToPtxast(tree, undefined, {
-      topLevelDivision: options?.topLevelDivision ?? 'chapter',
+      topLevelDivision:
+        options?.topLevelDivision ??
+        (options?.documentRoot
+          ? rootChildDivision(options.documentRoot)
+          : 'chapter'),
+      documentRoot: options?.documentRoot,
       topLevelAttributes: options?.topLevelAttributes,
     });
   };


### PR DESCRIPTION
This adds `division: article` as frontmatter that converts correctly.

It also implements the leaf node directive `::section{ref="mysection"}` to convert to `<plus:section ref="mysection"/>` 